### PR TITLE
Add RSASSA-PSS encryption OID to AlgorithmIdentifier

### DIFF
--- a/src/CryptoTypes/AlgorithmIdentifier/AlgorithmIdentifier.php
+++ b/src/CryptoTypes/AlgorithmIdentifier/AlgorithmIdentifier.php
@@ -29,6 +29,8 @@ abstract class AlgorithmIdentifier implements AlgorithmIdentifierType
 
     final public const OID_SHA1_WITH_RSA_ENCRYPTION = '1.2.840.113549.1.1.5';
 
+    final public const OID_RSASSA_PSS_ENCRYPTION = '1.2.840.113549.1.1.10';
+
     final public const OID_SHA256_WITH_RSA_ENCRYPTION = '1.2.840.113549.1.1.11';
 
     final public const OID_SHA384_WITH_RSA_ENCRYPTION = '1.2.840.113549.1.1.12';

--- a/src/CryptoTypes/Asymmetric/OneAsymmetricKey.php
+++ b/src/CryptoTypes/Asymmetric/OneAsymmetricKey.php
@@ -181,8 +181,9 @@ class OneAsymmetricKey
     {
         $algo = $this->algorithmIdentifier();
         switch ($algo->oid()) {
-            // RSA
+            // RSA (including RSASSA-PSS)
             case AlgorithmIdentifier::OID_RSA_ENCRYPTION:
+            case AlgorithmIdentifier::OID_RSASSA_PSS_ENCRYPTION:
                 return RSAPrivateKey::fromDER($this->privateKeyData);
                 // elliptic curve
             case AlgorithmIdentifier::OID_EC_PUBLIC_KEY:
@@ -225,8 +226,9 @@ class OneAsymmetricKey
                 return X448PrivateKey::fromOctetString(OctetString::fromDER($this->privateKeyData), $pubkey)
                     ->withVersion($this->version)
                     ->withAttributes($this->attributes);
+            default:
+                throw new RuntimeException('Private key ' . $algo->name() . ' not supported.');
         }
-        throw new RuntimeException('Private key ' . $algo->name() . ' not supported.');
     }
 
     /**


### PR DESCRIPTION
The Object Identifier (OID) for the RSASSA-PSS encryption algorithm has been added to the AlgorithmIdentifier class. Adjustments have also been made to handle this additional case in OneAsymmetricKey. This enhances support for encryption variety and expands compatibility.

| Q             | A
| ------------- | ---
| Branch?       | 1.2
| Bug fix?      | yes #49 
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
