### PR TITLE
Make nullable parameters explicity nullable for PHP 8.4

### DIFF
--- a/src/ASN1/Component/Identifier.php
+++ b/src/ASN1/Component/Identifier.php
@@ -87,7 +87,7 @@ final class Identifier implements Encodable
      * Variable is updated to the offset next to the
      * parsed identifier. If null, start from offset 0.
      */
-    public static function fromDER(string $data, int &$offset = null): self
+    public static function fromDER(string $data, ?int &$offset = null): self
     {
         $idx = $offset ?? 0;
         $datalen = mb_strlen($data, '8bit');

--- a/src/ASN1/Component/Length.php
+++ b/src/ASN1/Component/Length.php
@@ -49,7 +49,7 @@ final class Length implements Encodable
      * Variable is updated to the offset next to the
      * parsed length component. If null, start from offset 0.
      */
-    public static function fromDER(string $data, int &$offset = null): self
+    public static function fromDER(string $data, ?int &$offset = null): self
     {
         $idx = $offset ?? 0;
         $datalen = mb_strlen($data, '8bit');
@@ -89,7 +89,7 @@ final class Length implements Encodable
      * @param null|int $expected Expected length, null to bypass checking
      * @see self::fromDER
      */
-    public static function expectFromDER(string $data, int &$offset, int $expected = null): self
+    public static function expectFromDER(string $data, int &$offset, ?int $expected = null): self
     {
         $idx = $offset;
         $length = self::fromDER($data, $idx);

--- a/src/ASN1/Element.php
+++ b/src/ASN1/Element.php
@@ -240,7 +240,7 @@ abstract class Element implements ElementBase
      * Variable is updated to the offset next to the
      * parsed element. If null, start from offset 0.
      */
-    public static function fromDER(string $data, int &$offset = null): static
+    public static function fromDER(string $data, ?int &$offset = null): static
     {
         $idx = $offset ?? 0;
         // decode identifier

--- a/tests/CryptoTypes/Unit/AlgoId/AlgorithmIdentifierTest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/AlgorithmIdentifierTest.php
@@ -51,7 +51,7 @@ final class AlgorithmIdentifierTest extends TestCase
 
     #[Test]
     #[Depends('fromUnknownASN1')]
-    public function verifyName(AlgorithmIdentifier $algo = null): void
+    public function verifyName(?AlgorithmIdentifier $algo = null): void
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Asymmetric/ECPKAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Asymmetric/ECPKAITest.php
@@ -58,7 +58,7 @@ final class ECPKAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Asymmetric/RSAEncAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Asymmetric/RSAEncAITest.php
@@ -49,7 +49,7 @@ final class RSAEncAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Cipher/AES128CBCAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Cipher/AES128CBCAITest.php
@@ -79,7 +79,7 @@ final class AES128CBCAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Cipher/AES192CBCAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Cipher/AES192CBCAITest.php
@@ -79,7 +79,7 @@ final class AES192CBCAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Cipher/AES256CBCAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Cipher/AES256CBCAITest.php
@@ -79,7 +79,7 @@ final class AES256CBCAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Cipher/DESCBCAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Cipher/DESCBCAITest.php
@@ -87,7 +87,7 @@ final class DESCBCAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Cipher/DESEDE3CBCAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Cipher/DESEDE3CBCAITest.php
@@ -79,7 +79,7 @@ final class DESEDE3CBCAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Cipher/RC2CBCAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Cipher/RC2CBCAITest.php
@@ -116,7 +116,7 @@ final class RC2CBCAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/GenericAlgorithmIdentifierTest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/GenericAlgorithmIdentifierTest.php
@@ -27,7 +27,7 @@ final class GenericAlgorithmIdentifierTest extends TestCase
 
     #[Test]
     #[Depends('create')]
-    public function verifyName(GenericAlgorithmIdentifier $ai = null): void
+    public function verifyName(?GenericAlgorithmIdentifier $ai = null): void
     {
         static::assertSame('1.3.6.1.3', $ai->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA1AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA1AITest.php
@@ -50,7 +50,7 @@ final class HMACWithSHA1AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA224AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA224AITest.php
@@ -39,7 +39,7 @@ final class HMACWithSHA224AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA256AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA256AITest.php
@@ -39,7 +39,7 @@ final class HMACWithSHA256AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA384AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA384AITest.php
@@ -39,7 +39,7 @@ final class HMACWithSHA384AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA512AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/HMACWithSHA512AITest.php
@@ -39,7 +39,7 @@ final class HMACWithSHA512AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/MD5AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/MD5AITest.php
@@ -48,7 +48,7 @@ final class MD5AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function naverifyNameme(AlgorithmIdentifier $algo = null)
+    public function naverifyNameme(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/SHA1AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/SHA1AITest.php
@@ -49,7 +49,7 @@ final class SHA1AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/SHA224AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/SHA224AITest.php
@@ -49,7 +49,7 @@ final class SHA224AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/SHA256AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/SHA256AITest.php
@@ -39,7 +39,7 @@ final class SHA256AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/SHA384AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/SHA384AITest.php
@@ -39,7 +39,7 @@ final class SHA384AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Hash/SHA512AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Hash/SHA512AITest.php
@@ -39,7 +39,7 @@ final class SHA512AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA1AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA1AITest.php
@@ -50,7 +50,7 @@ final class ECDSAWithSHA1AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA224AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA224AITest.php
@@ -39,7 +39,7 @@ final class ECDSAWithSHA224AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA256AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA256AITest.php
@@ -39,7 +39,7 @@ final class ECDSAWithSHA256AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA384AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA384AITest.php
@@ -39,7 +39,7 @@ final class ECDSAWithSHA384AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA512AITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/ECDSAWithSHA512AITest.php
@@ -39,7 +39,7 @@ final class ECDSAWithSHA512AITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/MD2WithRSAAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/MD2WithRSAAITest.php
@@ -39,7 +39,7 @@ final class MD2WithRSAAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/MD4WithRSAAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/MD4WithRSAAITest.php
@@ -39,7 +39,7 @@ final class MD4WithRSAAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/MD5WithRSAAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/MD5WithRSAAITest.php
@@ -39,7 +39,7 @@ final class MD5WithRSAAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/SHA1WithRSAAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/SHA1WithRSAAITest.php
@@ -55,7 +55,7 @@ final class SHA1WithRSAAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null): void
+    public function verifyName(?AlgorithmIdentifier $algo = null): void
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/SHA224WithRSAAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/SHA224WithRSAAITest.php
@@ -36,7 +36,7 @@ final class SHA224WithRSAAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/SHA256WithRSAAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/SHA256WithRSAAITest.php
@@ -39,7 +39,7 @@ final class SHA256WithRSAAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/SHA384WithRSAAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/SHA384WithRSAAITest.php
@@ -39,7 +39,7 @@ final class SHA384WithRSAAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/CryptoTypes/Unit/AlgoId/Signature/SHA512WithRSAAITest.php
+++ b/tests/CryptoTypes/Unit/AlgoId/Signature/SHA512WithRSAAITest.php
@@ -39,7 +39,7 @@ final class SHA512WithRSAAITest extends TestCase
 
     #[Test]
     #[Depends('decode')]
-    public function verifyName(AlgorithmIdentifier $algo = null)
+    public function verifyName(?AlgorithmIdentifier $algo = null)
     {
         static::assertIsString($algo->name());
     }

--- a/tests/X501/Unit/ASN1/AttributeTypeTest.php
+++ b/tests/X501/Unit/ASN1/AttributeTypeTest.php
@@ -63,7 +63,7 @@ final class AttributeTypeTest extends TestCase
 
     #[Test]
     #[Depends('create')]
-    public function verifyName(AttributeType $type = null)
+    public function verifyName(?AttributeType $type = null)
     {
         static::assertSame('name', $type->typeName());
     }

--- a/tests/X509/Unit/Ac/V2FormTest.php
+++ b/tests/X509/Unit/Ac/V2FormTest.php
@@ -91,7 +91,7 @@ final class V2FormTest extends TestCase
 
     #[Test]
     #[Depends('create')]
-    public function verifyName(V2Form $issuer = null)
+    public function verifyName(?V2Form $issuer = null)
     {
         static::assertSame('cn=Test', $issuer->name()->toString());
     }

--- a/tests/X509/Unit/Certificate/Extension/IssuerAlternativeNameTest.php
+++ b/tests/X509/Unit/Certificate/Extension/IssuerAlternativeNameTest.php
@@ -77,7 +77,7 @@ final class IssuerAlternativeNameTest extends TestCase
 
     #[Test]
     #[Depends('create')]
-    public function verifyName(IssuerAlternativeNameExtension $ext = null)
+    public function verifyName(?IssuerAlternativeNameExtension $ext = null)
     {
         static::assertSame(self::DN, $ext->names()->firstDN()->toString());
     }

--- a/tests/X509/Unit/Certificate/Extension/SubjectAlternativeNameTest.php
+++ b/tests/X509/Unit/Certificate/Extension/SubjectAlternativeNameTest.php
@@ -77,7 +77,7 @@ final class SubjectAlternativeNameTest extends TestCase
 
     #[Test]
     #[Depends('create')]
-    public function verifyName(SubjectAlternativeNameExtension $ext = null)
+    public function verifyName(?SubjectAlternativeNameExtension $ext = null)
     {
         static::assertSame(self::DN, $ext->names()->firstDN()->toString());
     }

--- a/tests/X509/Unit/Certificate/Extension/Target/TargetGroupTest.php
+++ b/tests/X509/Unit/Certificate/Extension/Target/TargetGroupTest.php
@@ -67,7 +67,7 @@ final class TargetGroupTest extends TestCase
 
     #[Test]
     #[Depends('create')]
-    public function verifyName(TargetGroup $target = null)
+    public function verifyName(?TargetGroup $target = null)
     {
         $name = $target->name();
         static::assertInstanceOf(GeneralName::class, $name);

--- a/tests/X509/Unit/Certificate/Extension/Target/TargetNameTest.php
+++ b/tests/X509/Unit/Certificate/Extension/Target/TargetNameTest.php
@@ -67,7 +67,7 @@ final class TargetNameTest extends TestCase
 
     #[Test]
     #[Depends('create')]
-    public function verifyName(TargetName $target = null)
+    public function verifyName(?TargetName $target = null)
     {
         $name = $target->name();
         static::assertInstanceOf(GeneralName::class, $name);

--- a/tests/X509/Unit/CertificationPath/CertificationPathValidationTest.php
+++ b/tests/X509/Unit/CertificationPath/CertificationPathValidationTest.php
@@ -53,7 +53,7 @@ final class CertificationPathValidationTest extends TestCase
 
     #[Test]
     #[Depends('validateDefault')]
-    public function verifyResult(PathValidationResult $result = null)
+    public function verifyResult(?PathValidationResult $result = null)
     {
         $expected_cert = Certificate::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/acme-ecdsa.pem'));
         static::assertEquals($expected_cert, $result->certificate());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.2.x
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes

Implicitly nullable parameter types are deprecated in PHP 8.4

https://www.php.net/manual/it/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter