### PR TITLE
Add support for brick/math 0.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "require": {
         "php": ">=8.1",
         "ext-mbstring": "*",
-        "brick/math": "^0.10|^0.11|^0.12|^0.13"
+        "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14"
     },
     "require-dev": {
         "ext-gmp": "*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This adds support for the latest version of `brick/math`: https://github.com/brick/math/releases/tag/0.14.0

This package is not affected by BC breaks:
- the PHP min version change is not actually a BC break (unlike in the npm ecosystem) as Composer takes the PHP requirement into account during dependency resolution. Thus, it does not affect this library (even though this library still supports PHP 8.1) because I'm adding support for the new version, but not removing support for the previous version
- this library *uses* classes from brick/math but does not *extend* them (and so is unaffected by the actual BC breaks)