### PR TITLE
Initialize the working_issuer_name with the subject name

### DIFF
--- a/src/X509/CertificationPath/PathValidation/ValidatorState.php
+++ b/src/X509/CertificationPath/PathValidation/ValidatorState.php
@@ -141,7 +141,7 @@ final class ValidatorState
         $state->_workingPublicKeyParameters = self::getAlgorithmParameters(
             $state->_workingPublicKey->algorithmIdentifier()
         );
-        $state->_workingIssuerName = $tbsCert->issuer();
+        $state->_workingIssuerName = $tbsCert->subject();
         $state->_maxPathLength = $config->maxLength();
         return $state;
     }

--- a/tests/X509/Unit/CertificationPath/CertificationPathValidationTest.php
+++ b/tests/X509/Unit/CertificationPath/CertificationPathValidationTest.php
@@ -94,4 +94,14 @@ final class CertificationPathValidationTest extends TestCase
         $validator = PathValidator::create(Crypto::getDefault(), $config, ...self::$_path->certificates());
         static::assertInstanceOf(PathValidationResult::class, $validator->validate());
     }
+
+    #[Test]
+    public function explicitTrustAnchorWithIntermediateCA()
+    {
+        $trustAnchor = self::$_path->certificates()[1];
+        $certs = [self::$_path->certificates()[2]];
+        $config = PathValidationConfig::defaultConfig()->withTrustAnchor($trustAnchor);
+        $validator = PathValidator::create(Crypto::getDefault(), $config, ...$certs);
+        static::assertInstanceOf(PathValidationResult::class, $validator->validate());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.5.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->

### Overview

We should initialize the `working_issuer_name` with the `subject name` of the `trust anchor`.

### Why

1. [working_issuer_name](https://datatracker.ietf.org/doc/html/rfc5280#section-6.1.1:~:text=anchor%20information.%0A%0A%20%20%20%20%20%20(j)-,working_issuer_name,-%3A%20%20the%20issuer%20distinguished): the issuer name of the next certificate in the chain. Should be initialized to a trusted issuer name of the provided trust anchor info.
2. [trusted issuer name](https://datatracker.ietf.org/doc/html/rfc5280#section-6.1.1:~:text=information%20includes%3A%0A%0A%20%20%20%20%20%20%20%20%20(1)-,the%20trusted%20issuer%20name,-%2C%0A%0A%20%20%20%20%20%20%20%20%20(2)%20%20the%20trusted): the subject field of trust anchor should be used as the trusted issuer name.
> When the trust anchor information is provided in the form of a
      certificate, the name in the subject field is used as the trusted
      issuer name and the contents of the subjectPublicKeyInfo field is
      used as the source of the trusted public key algorithm and the
      trusted public key. 
3. [trust anchor](https://datatracker.ietf.org/doc/html/rfc5280#section-6.1.1:~:text=The%20selection%20of%20a%20trust%20anchor%20is%20a%20matter%20of%20policy): it could be
    1. the top CA in a hierarchical PKI
    2. the cA that issued the verifier's own certificate
    3. any other CA in a network PKI