### PR TITLE
ci: check out the full history in the release workflow

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -7,6 +7,10 @@ name: "Automatic Releases"
 # locally, and the following commands require it. Splitting them into separate
 # jobs gives each one a fresh checkout of the default branch, so every release
 # made from an older branch fails with "not a valid object name".
+#
+# The checkout must be unshallow for the same reason: "switch-default-branch-
+# to-next-minor" resolves the newest release branch locally, and the default
+# shallow clone only contains the ref that triggered the workflow.
 
 on:
   milestone:
@@ -21,6 +25,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v7"
+        with:
+          fetch-depth: 0
 
       - name: "Release"
         uses: "laminas/automatic-releases@1.26.2"


### PR DESCRIPTION
## Problem

`actions/checkout` defaults to a shallow clone that only contains the ref which triggered the workflow. The `switch-default-branch-to-next-minor` command has to resolve the newest release branch locally, so it dies on:

```
git branch temporary-branchXXXXXXXX 4.0.x
fatal: not a valid object name: '4.0.x'
```

The tag and the GitHub release are already published when this happens, so a failed run still looks like a successful release. What is silently lost are the three steps that come after: the default branch is not switched to the next minor, the changelog is not bumped and the next milestones are not created.

## Change

`fetch-depth: 0` on the checkout step, which is what web-token/jwt-framework already does. The header comment gains a note about this trap, next to the existing one about keeping the five commands inside a single job.

## Status in this repository

The 1.6.1 release earlier today went through, but only because the command had no pre-existing branch to resolve: it created `1.7.x` from the current ref instead of looking one up. That is luck rather than correctness. As soon as a next-minor branch exists ahead of a release, this repository fails exactly the way Spomky-Labs/cbor-php has been failing since April.
