### PR TITLE
ci: repair the pipeline (CodeQL language, ECS 13.3 set removal)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,22 +1,13 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
+# CodeQL has no PHP extractor, so the only source this repository exposes to it
+# is its GitHub Actions workflows. The `actions` language covers exactly that.
+
 name: "CodeQL"
 
 on:
   push:
     branches: [ "*.*.x" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "4.6.x", "4.7.x" ]
+    branches: [ "*.*.x" ]
   schedule:
     - cron: '37 10 * * 4'
 
@@ -32,11 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: [ 'actions' ]
 
     steps:
     - name: Checkout repository
@@ -47,28 +34,6 @@ jobs:
       uses: github/codeql-action/init@v4.37.3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.3
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4.37.3


### PR DESCRIPTION
Two independent breakages that keep the pipeline red on `1.6.x`. Neither is caused by a code change here; both come from tooling moving underneath us.

## 1. CodeQL analysed JavaScript in a PHP repository

Every push produced:

```
CodeQL detected code written in GitHub Actions, but not any written in
JavaScript/TypeScript. Confirm that there is some source code for
JavaScript/TypeScript in the project.
```

The matrix asked for `javascript`, and there is none. The job could never succeed.

CodeQL has no PHP extractor, so the library itself is out of reach. What it *can* read here is the workflows — the `actions` language, which is exactly what the failure message named. The job now analyses that, and passes on this PR.

Two related repairs:

- `pull_request` filtered on `4.6.x` / `4.7.x`, branches that never existed in this repository, so the workflow never ran on a PR. It now mirrors the `push` filter.
- The `Autobuild` step is dropped; it only applies to compiled languages.

## 2. ECS 13.3 removed `SetList::SYMPLIFY`

`ecs.php` aborts on an undefined constant before inspecting a single file. The Coding Standards job installs the highest matching versions, so it picks up 13.3 and fails everywhere — including on the first push of this PR.

The set had already been emptied and deprecated in 13.2: it returned no rules and only raised a notice, its content having moved into the `common` sets that `ecs.php` already imports. Dropping the import changes nothing about what is enforced, which is why no file needed reformatting.

Same class of breakage as the ECS 13 upgrade handled in 5d630ec3, one minor later.