### PR TITLE
ci: repair the pipeline against the current toolchain

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -39,7 +39,6 @@ return static function (ECSConfig $config): void {
     $config->import(SetList::DOCBLOCK);
     $config->import(SetList::ARRAY);
     $config->import(SetList::NAMESPACES);
-    $config->import(SetList::SYMPLIFY);
     $config->import(SetList::CONTROL_STRUCTURES);
     $config->import(SetList::COMMON);
 

--- a/src/ASN1/Type/Primitive/BitString.php
+++ b/src/ASN1/Type/Primitive/BitString.php
@@ -151,7 +151,7 @@ final class BitString extends BaseString
 
     protected function encodedAsDER(): string
     {
-        $der = chr($this->unusedBits);
+        $der = chr($this->unusedBits & 0xFF);
         $der .= $this->string();
         if ($this->unusedBits !== 0) {
             $octet = $der[mb_strlen($der, '8bit') - 1];

--- a/src/ASN1/Type/Primitive/ObjectIdentifier.php
+++ b/src/ASN1/Type/Primitive/ObjectIdentifier.php
@@ -147,7 +147,7 @@ final class ObjectIdentifier extends Element
         foreach ($subids as $subid) {
             // if number fits to one base 128 byte
             if ($subid->isLessThan(128)) {
-                $data .= chr($subid->toInt());
+                $data .= chr($subid->toInt() & 0xFF);
             } else { // encode to multiple bytes
                 $bytes = [];
                 do {

--- a/src/ASN1/Type/Primitive/Real.php
+++ b/src/ASN1/Type/Primitive/Real.php
@@ -330,10 +330,10 @@ final class Real extends Element implements Stringable
         }
         if ($exp_len <= 3) {
             $byte |= ($exp_len - 1) & 0x03;
-            $bytes = chr($byte);
+            $bytes = chr($byte & 0xFF);
         } else {
             $byte |= 0x03;
-            $bytes = chr($byte) . chr($exp_len);
+            $bytes = chr($byte & 0xFF) . chr($exp_len & 0xFF);
         }
         $bytes .= $exp_bytes;
         // encode mantissa

--- a/src/ASN1/Type/Primitive/RelativeOID.php
+++ b/src/ASN1/Type/Primitive/RelativeOID.php
@@ -112,7 +112,7 @@ final class RelativeOID extends Element
         foreach ($subids as $subid) {
             // if number fits to one base 128 byte
             if ($subid->isLessThan(128)) {
-                $data .= chr($subid->toInt());
+                $data .= chr($subid->toInt() & 0xFF);
             } else { // encode to multiple bytes
                 $bytes = [];
                 do {


### PR DESCRIPTION
Rebased on `1.6.x` now that #95 has landed: the CodeQL part of this branch is gone, it is covered there. What remains are the two toolchain breakages that #95 did not touch.

### Coding Standards — currently red on `1.6.x`

`symplify/easy-coding-standard` 13.3.2 (released today) removed `SetList::SYMPLIFY`, so `ecs.php` cannot be loaded at all. The run on `1.6.x` right after #95:

```
[ERROR] Undefined constant Symplify\EasyCodingStandard\ValueObject\Set\SetList::SYMPLIFY
make: *** [Makefile:39: ci-cs] Error 1
```

The import is dropped. None of the fixers in that set were reformatting anything — `ecs check` is clean on the whole codebase without it, with no reformatting commit needed.

### Static Analysis — green in CI, red locally

This one is preventive, so drop it if you would rather keep the PR to the blocker. The PHPStan development branch — what `dependency-versions: highest` resolves to, `minimum-stability` being `dev` — narrowed the `chr()` parameter to `int<0, 255>`:

```
src/ASN1/Type/Primitive/BitString.php:154
src/ASN1/Type/Primitive/ObjectIdentifier.php:150
src/ASN1/Type/Primitive/Real.php:333
src/ASN1/Type/Primitive/RelativeOID.php:115
    Parameter #1 $codepoint of function chr expects int<0, 255>, int given.
```

CI has not picked that snapshot up yet, so the job is still passing there; it fails against a fresh `composer update` today. Each argument is masked with `& 0xFF`, which is exactly what `chr()` already applies internally — the encoded output is unchanged, the mask only makes the byte-width intent visible to the analyser.

### Verified locally

`vendor/bin/ecs check`, `vendor/bin/phpstan analyse`, `vendor/bin/rector process --dry-run` and the full test suite (2588 tests) all pass.