### PR TITLE
fix(ci): repair the static analysis, coding standards and CodeQL jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ on:
     branches: [ "*.*.x" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "4.6.x", "4.7.x" ]
+    branches: [ "*.*.x" ]
   schedule:
     - cron: '37 10 * * 4'
 
@@ -32,10 +32,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # The library is written in PHP, which CodeQL does not support.
+        # The GitHub Actions workflows are the only thing it can analyze here.
+        language: [ 'actions' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
@@ -54,21 +53,6 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.3
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4.37.3

--- a/ecs.php
+++ b/ecs.php
@@ -39,7 +39,6 @@ return static function (ECSConfig $config): void {
     $config->import(SetList::DOCBLOCK);
     $config->import(SetList::ARRAY);
     $config->import(SetList::NAMESPACES);
-    $config->import(SetList::SYMPLIFY);
     $config->import(SetList::CONTROL_STRUCTURES);
     $config->import(SetList::COMMON);
 

--- a/src/ASN1/Type/Primitive/BitString.php
+++ b/src/ASN1/Type/Primitive/BitString.php
@@ -151,7 +151,7 @@ final class BitString extends BaseString
 
     protected function encodedAsDER(): string
     {
-        $der = chr($this->unusedBits);
+        $der = chr($this->unusedBits & 0xFF);
         $der .= $this->string();
         if ($this->unusedBits !== 0) {
             $octet = $der[mb_strlen($der, '8bit') - 1];

--- a/src/ASN1/Type/Primitive/ObjectIdentifier.php
+++ b/src/ASN1/Type/Primitive/ObjectIdentifier.php
@@ -147,7 +147,7 @@ final class ObjectIdentifier extends Element
         foreach ($subids as $subid) {
             // if number fits to one base 128 byte
             if ($subid->isLessThan(128)) {
-                $data .= chr($subid->toInt());
+                $data .= chr($subid->toInt() & 0xFF);
             } else { // encode to multiple bytes
                 $bytes = [];
                 do {

--- a/src/ASN1/Type/Primitive/Real.php
+++ b/src/ASN1/Type/Primitive/Real.php
@@ -330,10 +330,10 @@ final class Real extends Element implements Stringable
         }
         if ($exp_len <= 3) {
             $byte |= ($exp_len - 1) & 0x03;
-            $bytes = chr($byte);
+            $bytes = chr($byte & 0xFF);
         } else {
             $byte |= 0x03;
-            $bytes = chr($byte) . chr($exp_len);
+            $bytes = chr($byte & 0xFF) . chr($exp_len & 0xFF);
         }
         $bytes .= $exp_bytes;
         // encode mantissa

--- a/src/ASN1/Type/Primitive/RelativeOID.php
+++ b/src/ASN1/Type/Primitive/RelativeOID.php
@@ -112,7 +112,7 @@ final class RelativeOID extends Element
         foreach ($subids as $subid) {
             // if number fits to one base 128 byte
             if ($subid->isLessThan(128)) {
-                $data .= chr($subid->toInt());
+                $data .= chr($subid->toInt() & 0xFF);
             } else { // encode to multiple bytes
                 $bytes = [];
                 do {


### PR DESCRIPTION
Three jobs of the pipeline are red on `1.6.x` for reasons unrelated to the library code.

- **Coding Standards**: ECS 13.3 removed the deprecated `symplify` set (its rules now live in the `common` sets, which `ecs.php` already imports). The reference to the missing `SetList::SYMPLIFY` constant makes ECS fatal on start-up.
- **Static Analysis**: PHPStan now types the first argument of `chr()` as `int<0, 255>`. The four DER encoding call sites are masked with `0xFF`, which is exactly what `chr()` does internally, so the encoded output is unchanged.
- **CodeQL**: the repository contains no JavaScript, so the analysis ends with `Only found JavaScript or TypeScript files that were empty or contained syntax errors` and the job fails. CodeQL has no PHP support, so the GitHub Actions workflows are analysed instead. The `pull_request` branch filter was also still pointing at `4.6.x`/`4.7.x`, branches of another project.

Checked locally: `phpunit` (2576 tests), `phpstan`, `ecs`, `rector --dry-run` and `parallel-lint` all pass.