### PR TITLE
ci: repair the Coding Standards and CodeQL jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ on:
     branches: [ "*.*.x" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "4.6.x", "4.7.x" ]
+    branches: [ "*.*.x" ]
   schedule:
     - cron: '37 10 * * 4'
 
@@ -32,11 +32,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # This is a PHP library, a language CodeQL does not support. The workflows themselves are
+        # analysed instead; asking for 'javascript' fails the job with a configuration error, as no
+        # JavaScript/TypeScript source is seen during the build.
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: [ 'actions' ]
 
     steps:
     - name: Checkout repository

--- a/ecs.php
+++ b/ecs.php
@@ -39,7 +39,6 @@ return static function (ECSConfig $config): void {
     $config->import(SetList::DOCBLOCK);
     $config->import(SetList::ARRAY);
     $config->import(SetList::NAMESPACES);
-    $config->import(SetList::SYMPLIFY);
     $config->import(SetList::CONTROL_STRUCTURES);
     $config->import(SetList::COMMON);
 


### PR DESCRIPTION
Two jobs of the pipeline fail on `1.6.x` for reasons unrelated to the library itself.

**Coding Standards.** `composer.lock` is not committed, so CI always resolves the newest dependencies. easy-coding-standard 13.3.2, released today, removed `SetList::SYMPLIFY`, and `ecs.php` now fatals before a single file is checked:

```
[ERROR] Undefined constant Symplify\EasyCodingStandard\ValueObject\Set\SetList::SYMPLIFY
```

The set no longer exists, so the import is dropped. `vendor/bin/ecs check` reports no violation on the codebase afterwards, i.e. the set was not contributing any rule that the remaining ones do not already cover.

**CodeQL.** The job asks for the `javascript` language and fails with a configuration error:

```
CodeQL detected code written in GitHub Actions, but not any written in JavaScript/TypeScript.
```

There is no JavaScript or TypeScript in this repository and CodeQL has no PHP support, so the workflows themselves are analysed instead. The pull request filter also listed `4.6.x` and `4.7.x`, branches that never existed here, which kept the job from ever running on a pull request; it now follows the same pattern as the push filter.