### PR TITLE
docs: indent the README bullet continuations to four spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ composer require spomky-labs/pki-framework
 contains is chosen by whoever submitted it**, so an issuer must treat it as untrusted input:
 
 - the signature of the request is **not** verified by `fromCSR()`. Call `CertificationRequest::verify()` yourself
-  before using it;
+    before using it;
 - extensions that decide what a certificate is allowed to do — `basicConstraints`, `keyUsage`, `extKeyUsage`,
-  `nameConstraints`, `policyConstraints`, `policyMappings`, `inhibitAnyPolicy`, `certificatePolicies` and
-  `authorityKeyIdentifier` — are never copied from the request. They belong to the issuer, which sets them with
-  `withExtensions()` / `withAdditionalExtensions()`;
+    `nameConstraints`, `policyConstraints`, `policyMappings`, `inhibitAnyPolicy`, `certificatePolicies` and
+    `authorityKeyIdentifier` — are never copied from the request. They belong to the issuer, which sets them with
+    `withExtensions()` / `withAdditionalExtensions()`;
 - every other requested extension **is** copied, `subjectAltName` included. Pass the OIDs the issuer is willing to
-  honour as the second argument to restrict the copy:
+    honour as the second argument to restrict the copy:
 
 ```php
 $tbsCertificate = TBSCertificate::fromCSR($csr, [Extension::OID_SUBJECT_ALT_NAME]);


### PR DESCRIPTION
## Problem

The Coding Standards job fails on every push to `1.6.x`:

```
README.md:
38:3: indentation size doesn't match expected 4, got 2
40:3: indentation size doesn't match expected 4, got 2
41:3: indentation size doesn't match expected 4, got 2
42:3: indentation size doesn't match expected 4, got 2
44:3: indentation size doesn't match expected 4, got 2
```

`eclint` checks the repository against `.editorconfig`, which sets `indent_size = 4` for every file type but YAML. The bullet list in the certification-request section wraps its items at two spaces.

## Fix

The five continuation lines move to four spaces. That is still a lazy continuation of the list item — well below the six spaces that would turn it into an indented code block — so the list renders exactly as before.

Verified with the same `greut/eclint` image the workflow uses: it reports those five lines on the current `1.6.x` and exits 0 with this change.