### PR TITLE
fix(asn1): walk indefinite length content when decoding tagged types

### DIFF
--- a/src/ASN1/Type/Tagged/DERTaggedType.php
+++ b/src/ASN1/Type/Tagged/DERTaggedType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\Pki\ASN1\Type\Tagged;
 
+use function mb_strlen;
 use SpomkyLabs\Pki\ASN1\Component\Identifier;
 use SpomkyLabs\Pki\ASN1\Component\Length;
 use SpomkyLabs\Pki\ASN1\Element;
@@ -88,6 +89,10 @@ class DERTaggedType extends TaggedType implements ExplicitTagging, ImplicitTaggi
             if ($identifier->isPrimitive()) {
                 throw new DecodeException('Primitive type with indefinite length is not supported.');
             }
+            // An indefinite length states no size up front: the content runs until the matching end-of-contents.
+            // Walking it is what moves the offset past the element, so that the caller resumes on the next
+            // sibling instead of inside this one.
+            $idx = self::skipIndefiniteContent($data, $idx);
             // EOC consists of two octets.
             $value_length = $idx - $value_offset - 2;
         } else {
@@ -98,6 +103,28 @@ class DERTaggedType extends TaggedType implements ExplicitTagging, ImplicitTaggi
         $type = static::create($identifier, $data, $offset, $value_offset, $value_length, $length->isIndefinite());
         $offset = $idx;
         return $type;
+    }
+
+    /**
+     * Walk an indefinite length content and return the offset just past its end-of-contents octets.
+     *
+     * @param string $data DER data
+     * @param int $offset Offset to the first content octet
+     */
+    private static function skipIndefiniteContent(string $data, int $offset): int
+    {
+        $end = mb_strlen($data, '8bit');
+        $idx = $offset;
+        while (true) {
+            if ($idx >= $end) {
+                throw new DecodeException('Unexpected end of data while decoding indefinite length element.');
+            }
+            $element = Element::fromDER($data, $idx);
+            $idx ??= $end;
+            if ($element->isType(Element::TYPE_EOC)) {
+                return $idx;
+            }
+        }
     }
 
     protected function encodedAsDER(): string

--- a/tests/ASN1/Tagging/IndefiniteLengthTaggedDecodeTest.php
+++ b/tests/ASN1/Tagging/IndefiniteLengthTaggedDecodeTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\ASN1\Tagging;
+
+use function chr;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\ASN1\Element;
+use SpomkyLabs\Pki\ASN1\Exception\DecodeException;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
+use SpomkyLabs\Pki\ASN1\Type\Tagged\ContextSpecificType;
+use SpomkyLabs\Pki\ASN1\Type\TaggedType;
+
+/**
+ * An indefinite length states no size up front, so the decoder has to walk the content to find the matching
+ * end-of-contents. It did not: the offset stayed just after the length octets and the content length came out
+ * as -2, which spilled the element's content into the enclosing structure as siblings.
+ *
+ * @internal
+ */
+final class IndefiniteLengthTaggedDecodeTest extends TestCase
+{
+    /**
+     * [0] with indefinite length, holding INTEGER 1.
+     *
+     * @var string
+     */
+    private const TAGGED = 'a0800201010000';
+
+    #[Test]
+    public function decodingConsumesTheWholeElement(): void
+    {
+        $der = hex2bin(self::TAGGED);
+        $offset = 0;
+        TaggedType::fromDER($der, $offset);
+
+        static::assertSame(mb_strlen($der, '8bit'), $offset);
+    }
+
+    #[Test]
+    public function contentDoesNotSpillIntoTheEnclosingStructure(): void
+    {
+        // SEQUENCE { [0] { INTEGER 1 }, INTEGER 2 } holds two elements, not four.
+        $seq = Element::fromDER(self::wrapInSequence(hex2bin(self::TAGGED) . hex2bin('020102')));
+
+        static::assertCount(2, $seq);
+        static::assertInstanceOf(ContextSpecificType::class, $seq->at(0)->asElement());
+        static::assertInstanceOf(Integer::class, $seq->at(1)->asElement());
+        static::assertSame(2, $seq->at(1)->asInteger()->intNumber());
+    }
+
+    #[Test]
+    public function theTaggedContentIsStillReadable(): void
+    {
+        $seq = Element::fromDER(self::wrapInSequence(hex2bin(self::TAGGED) . hex2bin('020102')));
+
+        static::assertSame(1, $seq->at(0)->asTagged()->asExplicit()->asInteger()->intNumber());
+    }
+
+    #[Test]
+    public function roundTripIsPreserved(): void
+    {
+        $der = hex2bin(self::TAGGED);
+
+        static::assertSame($der, TaggedType::fromDER($der)->toDER());
+    }
+
+    #[Test]
+    public function nestedIndefiniteLengthsAreHandled(): void
+    {
+        // [0] { [1] { INTEGER 1 } }
+        $der = hex2bin('a080a1800201010000') . "\x00\x00";
+        $offset = 0;
+        $el = TaggedType::fromDER($der, $offset);
+
+        static::assertSame(mb_strlen($der, '8bit'), $offset);
+        static::assertSame(1, $el->asExplicit()->asTagged()->asExplicit()->asInteger()->intNumber());
+    }
+
+    #[Test]
+    public function severalIndefiniteLengthSiblingsAreSeparated(): void
+    {
+        $seq = Element::fromDER(self::wrapInSequence(hex2bin(self::TAGGED) . hex2bin(self::TAGGED)));
+
+        static::assertCount(2, $seq);
+        static::assertSame(1, $seq->at(0)->asTagged()->asExplicit()->asInteger()->intNumber());
+        static::assertSame(1, $seq->at(1)->asTagged()->asExplicit()->asInteger()->intNumber());
+    }
+
+    #[Test]
+    public function aMissingEndOfContentsIsRejected(): void
+    {
+        // Without a terminating EOC the decoder must stop rather than run past the end of the buffer.
+        $this->expectException(DecodeException::class);
+        $this->expectExceptionMessage('Unexpected end of data');
+        TaggedType::fromDER(hex2bin('a080020101'));
+    }
+
+    private static function wrapInSequence(string $content): string
+    {
+        return "\x30" . chr(mb_strlen($content, '8bit')) . $content;
+    }
+}


### PR DESCRIPTION
`DERTaggedType::decodeFromDER()` computed the content length as if the offset had
already moved past the content and the end-of-contents octets:

```php
if ($length->isIndefinite()) {
    // ...
    // EOC consists of two octets.
    $value_length = $idx - $value_offset - 2;   // $idx === $value_offset here, so always -2
}
```

Nothing moved it. Two consequences:

1. The offset was left just after the length octets, so the caller resumed parsing
   *inside* the element.
2. `$value_length` was `-2`, which `mb_substr()` reads as "everything but the last
   two bytes" — accidentally right for a standalone buffer, which is why the
   existing round-trip test passed and this stayed hidden.

```php
$der = hex2bin('a0800201010000');      // [0] { INTEGER 1 }
$offset = 0;
TaggedType::fromDER($der, $offset);
// $offset === 2, expected 7
```

Nested in a structure, the element's content becomes siblings:

```php
// SEQUENCE { [0] { INTEGER 1 }, INTEGER 2 }
count($seq);   // 4, expected 2
// [0] ContextSpecificType
// [1] Integer          <- the [0]'s own content
// [2] EOC              <- its terminator
// [3] Integer
```

The same encoding therefore means different things to this library and to a
conforming parser. A structure decoded this way has its fields shifted, so
accessors read neighbouring values. `ApplicationType` and `PrivateType` extend this
class and were affected identically.

## Change

Walk the content until the matching end-of-contents, the way
`Sequence::decodeIndefiniteLength()` already does, and let that walk move the
offset. The `$value_length` expression that was written for it now gets the `$idx`
it assumed.

## Scope

Not a security advisory. Indefinite lengths are a BER construct that DER forbids,
and since `SignedDER` landed, signatures are verified over the received bytes
rather than a re-encoding, so a mis-parsed structure cannot be made to verify.
What it does affect is any structure decoded before or without signature
verification — path building, CSR parsing, attribute certificates — where field
shifting means accessors return the wrong values.

Found while working on GHSA-f28f-xc9q-m482: enforcing full input consumption in
`Element::fromDER()` surfaced it, and it was left out of that fix to keep the two
changes reviewable apart.

## Tests

`tests/ASN1/Tagging/IndefiniteLengthTaggedDecodeTest.php`:

- decoding consumes the whole element;
- the content does not spill into the enclosing structure, which decodes to two
  elements of the right types;
- the tagged content is still readable through `asExplicit()`;
- the round trip is preserved;
- nested indefinite lengths work;
- two indefinite-length siblings stay separate;
- a missing end-of-contents is rejected rather than running past the buffer.

`tests/ASN1/Tagging/IndefiniteTaggedTest`, which covered the standalone round trip,
passes unchanged.

## Verification

```
phpunit  2788 tests, 3346 assertions, no failures   (2781 before, +7)
ecs      no errors
phpstan  no errors
```
