### PR TITLE
Address the open hardening issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,18 @@ contains is chosen by whoever submitted it**, so an issuer must treat it as untr
     `nameConstraints`, `policyConstraints`, `policyMappings`, `inhibitAnyPolicy`, `certificatePolicies` and
     `authorityKeyIdentifier` — are never copied from the request. They belong to the issuer, which sets them with
     `withExtensions()` / `withAdditionalExtensions()`;
-- every other requested extension **is** copied, `subjectAltName` included. Pass the OIDs the issuer is willing to
-    honour as the second argument to restrict the copy:
+- **name the extensions you are willing to honour** as the second argument. Anything not named is dropped:
 
 ```php
 $tbsCertificate = TBSCertificate::fromCSR($csr, [Extension::OID_SUBJECT_ALT_NAME]);
 ```
+
+- leaving the argument out copies every requested extension that is not forbidden, `subjectAltName` and
+    `authorityInformationAccess` included, and raises a deprecation notice. That default is a deny list: the set of
+    extensions that matter grows over time and every future one is copied. It becomes the empty allow list in the
+    next major release. Pass `null` explicitly if you really want it;
+- an unknown extension marked critical is never copied. It would be signed verbatim and no conforming validator,
+    this library's own included, would then accept the certificate.
 
 ## Validating a certification path
 
@@ -80,13 +86,25 @@ $path->validate($config);
 
 Do not validate a chain a peer supplied without an anchor. Left to itself, validation would fall back to the first
 certificate of the path — one the peer chose — and confirm only that the chain is internally consistent. A path built
-by `CertificationPath::fromCertificateChain()` refuses to validate without an explicit anchor for that reason.
+by `CertificationPath::fromCertificateChain()` refuses to validate without an explicit anchor for that reason, and a
+path built by `CertificationPath::create()` raises a deprecation notice when it falls back, so an application can find
+the call sites before the fallback is removed in the next major release. A path built by `toTarget()` is already
+headed by a certificate from the trust list you gave it and needs neither.
 
 ## Security
 
 Path validation checks that a chain is well-formed and leads to a trust anchor you named. It does **not** check
 revocation: the library never contacts a CRL distribution point or an OCSP responder, so a revoked certificate still
 validates. Revocation is the calling application's responsibility.
+
+Attribute certificate validation does not implement RFC 5755 section 5 check 4 on its own: name the authorities you
+trust to issue attribute certificates with `ACValidationConfig::withTrustedAttributeAuthorities()`, or the validator
+accepts whatever end-entity certificate the issuer path ends in.
+
+`Certificate::equals()` compares the two encodings octet by octet, and `CertificateBundle::contains()` is built on
+it. Use `Certificate::hasEqualSubjectIdentity()` for the looser "same subject, same key, same serial number"
+question — it is not an identity check, since two certificates can agree on all three and still be issued by
+different issuers with different extensions.
 
 Found a vulnerability? Do not open a public issue — read [SECURITY.md](SECURITY.md) and report it privately.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Attribute certificate validation does not implement RFC 5755 section 5 check 4 o
 trust to issue attribute certificates with `ACValidationConfig::withTrustedAttributeAuthorities()`, or the validator
 accepts whatever end-entity certificate the issuer path ends in.
 
+Ed25519 and Ed448 are in the default set of allowed signature algorithms, but whether a signature made with them
+can be checked depends on the runtime: the OpenSSL extension only grew EdDSA recently, and `ext-sodium` — bundled
+since PHP 7.2 — covers Ed25519 alone. Verification fails closed where the runtime cannot do it. Ask
+`OpenSSLCrypto::supportsSignatureAlgorithm()` if you would rather narrow the configured set than have a chain
+refused during validation.
+
 `Certificate::equals()` compares the two encodings octet by octet, and `CertificateBundle::contains()` is built on
 it. Use `Certificate::hasEqualSubjectIdentity()` for the looser "same subject, same key, same serial number"
 question — it is not an identity check, since two certificates can agree on all three and still be issued by

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
     },
     "suggest": {
         "ext-openssl": "For OpenSSL based cyphering",
+        "ext-sodium": "To verify Ed25519 signatures where the OpenSSL extension has no EdDSA",
         "ext-gmp": "For better performance (or BCMath)",
         "ext-bcmath": "For better performance (or GMP)"
     },

--- a/src/ASN1/Component/Identifier.php
+++ b/src/ASN1/Component/Identifier.php
@@ -6,11 +6,14 @@ namespace SpomkyLabs\Pki\ASN1\Component;
 
 use function array_key_exists;
 use Brick\Math\BigInteger;
+use Brick\Math\Exception\MathException;
+use function func_num_args;
 use function mb_strlen;
 use function ord;
 use SpomkyLabs\Pki\ASN1\Exception\DecodeException;
 use SpomkyLabs\Pki\ASN1\Feature\Encodable;
 use SpomkyLabs\Pki\ASN1\Util\BigInt;
+use function sprintf;
 
 /**
  * Class to represent BER/DER identifier octets.
@@ -106,7 +109,7 @@ final class Identifier implements Encodable
         if ($tag === 0x1F) {
             $tag = self::decodeLongFormTag($data, $idx);
         }
-        if (isset($offset)) {
+        if (func_num_args() > 1) {
             $offset = $idx;
         }
         return self::create($class, $pc, $tag);
@@ -163,7 +166,13 @@ final class Identifier implements Encodable
      */
     public function intTag(): int
     {
-        return $this->_tag->toInt();
+        try {
+            return $this->_tag->toInt();
+        } catch (MathException $e) {
+            // a tag number that does not fit in an int can never name a type this decoder implements, and letting
+            // brick/math's overflow exception escape would break the decoding contract of Element::fromDER()
+            throw new DecodeException(sprintf('Tag number %s is too large.', $this->_tag->base10()), 0, $e);
+        }
     }
 
     /**
@@ -261,17 +270,28 @@ final class Identifier implements Encodable
     {
         $datalen = mb_strlen($data, '8bit');
         $tag = BigInteger::of(0);
+        $first = true;
         while (true) {
             if ($offset >= $datalen) {
                 throw new DecodeException('Unexpected end of data while decoding long form identifier.');
             }
             $byte = ord($data[$offset++]);
+            // the first subsequent octet must not be 0x80: leading zero bits are not part of a minimal encoding
+            // (X.690 sect. 8.1.2.4.2 c)
+            if ($first && $byte === 0x80) {
+                throw new DecodeException('Leading zero octet in a long form tag number.');
+            }
+            $first = false;
             $tag = $tag->shiftedLeft(7);
             $tag = $tag->or(0x7F & $byte);
             // last byte has bit 8 set to zero
             if ((0x80 & $byte) === 0) {
                 break;
             }
+        }
+        // a tag number below 31 must use the short form (X.690 sect. 8.1.2.3)
+        if ($tag->isLessThan(0x1F)) {
+            throw new DecodeException('Tag number must be encoded in the short form.');
         }
         return $tag;
     }

--- a/src/ASN1/Component/Length.php
+++ b/src/ASN1/Component/Length.php
@@ -8,6 +8,7 @@ use Brick\Math\BigInteger;
 use Brick\Math\Exception\MathException;
 use function count;
 use DomainException;
+use function func_num_args;
 use LogicException;
 use function mb_strlen;
 use function ord;
@@ -73,7 +74,7 @@ final class Length implements Encodable
                 $length = self::decodeLongFormLength($length, $data, $idx);
             }
         }
-        if (isset($offset)) {
+        if (func_num_args() > 1) {
             $offset = $idx;
         }
         return self::create($length, $indefinite);
@@ -216,11 +217,19 @@ final class Length implements Encodable
         if ($length === 127) {
             throw new DecodeException('Invalid number of length octets.');
         }
+        // leading zero octets are not part of a minimal encoding (X.690 sect. 10.1)
+        if (ord($data[$offset]) === 0x00) {
+            throw new DecodeException('Leading zero octet in a long form length.');
+        }
         $num = BigInteger::of(0);
         while (--$length >= 0) {
             $byte = ord($data[$offset++]);
             $num = $num->shiftedLeft(8)
                 ->or($byte);
+        }
+        // a length below 128 must use the short form (X.690 sect. 10.1)
+        if ($num->isLessThan(128)) {
+            throw new DecodeException('Length must be encoded in the short form.');
         }
 
         return $num;

--- a/src/ASN1/Element.php
+++ b/src/ASN1/Element.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\ASN1;
 
 use function array_key_exists;
+use function func_num_args;
+use function in_array;
 use InvalidArgumentException;
 use function mb_strlen;
 use SpomkyLabs\Pki\ASN1\Component\Identifier;
@@ -48,6 +50,7 @@ use SpomkyLabs\Pki\ASN1\Type\TaggedType;
 use SpomkyLabs\Pki\ASN1\Type\TimeType;
 use SpomkyLabs\Pki\ASN1\Type\UnspecifiedType;
 use function sprintf;
+use Throwable;
 use UnexpectedValueException;
 
 /**
@@ -150,6 +153,22 @@ abstract class Element implements ElementBase
      * @var int
      */
     public const DEFAULT_MAX_NESTING_DEPTH = 64;
+
+    /**
+     * Universal types that X.690 only ever allows to be encoded as a primitive.
+     *
+     * @internal
+     *
+     * @var list<int>
+     */
+    private const PRIMITIVE_ONLY_TYPES = [
+        self::TYPE_BOOLEAN,
+        self::TYPE_INTEGER,
+        self::TYPE_OBJECT_IDENTIFIER,
+        self::TYPE_REAL,
+        self::TYPE_ENUMERATED,
+        self::TYPE_RELATIVE_OID,
+    ];
 
     /**
      * Mapping from universal type tag to implementation class name.
@@ -280,12 +299,22 @@ abstract class Element implements ElementBase
                 ));
             }
             $idx = $offset ?? 0;
-            // decode identifier
-            $identifier = Identifier::fromDER($data, $idx);
-            // determine class that implements type specific decoding
-            $cls = self::determineImplClass($identifier);
-            // decode remaining element
-            $element = $cls::decodeFromDER($identifier, $data, $idx);
+            try {
+                // decode identifier
+                $identifier = Identifier::fromDER($data, $idx);
+                // determine class that implements type specific decoding
+                $cls = self::determineImplClass($identifier);
+                // decode remaining element
+                $element = $cls::decodeFromDER($identifier, $data, $idx);
+            } catch (DecodeException $e) {
+                throw $e;
+            } catch (Throwable $e) {
+                // the type specific decoders reach into brick/math, into type constructors and into string
+                // validation, any of which may signal malformed input with an exception of its own type. The
+                // documented contract of this method is that nothing but a DecodeException escapes, so the
+                // original is kept as the previous exception and the type is normalised here.
+                throw new DecodeException(sprintf('Failed to decode element: %s', $e->getMessage()), 0, $e);
+            }
         } finally {
             --self::$nestingDepth;
         }
@@ -297,8 +326,8 @@ abstract class Element implements ElementBase
                 throw new UnexpectedValueException(sprintf('%s expected, got %s.', $called_class, $element::class));
             }
         }
-        // update offset for the caller
-        if (isset($offset)) {
+        // update offset for the caller, also when the variable passed by reference was null
+        if (func_num_args() > 1) {
             $offset = $idx;
         }
         return $element;
@@ -460,12 +489,14 @@ abstract class Element implements ElementBase
     {
         switch ($identifier->typeClass()) {
             case Identifier::CLASS_UNIVERSAL:
-                $cls = self::determineUniversalImplClass($identifier->intTag());
+                $tag = $identifier->intTag();
+                $cls = self::determineUniversalImplClass($tag);
                 // constructed strings may be present in BER
                 if ($identifier->isConstructed()
                     && is_subclass_of($cls, StringType::class)) {
                     $cls = ConstructedString::class;
                 }
+                self::checkUniversalEncodingForm($tag, $identifier->isConstructed());
                 return $cls;
             case Identifier::CLASS_CONTEXT_SPECIFIC:
                 return ContextSpecificType::class;
@@ -492,6 +523,24 @@ abstract class Element implements ElementBase
             throw new UnexpectedValueException("Universal tag {$tag} not implemented.");
         }
         return self::MAP_TAG_TO_CLASS[$tag];
+    }
+
+    /**
+     * Check that an universal type whose contents are a single value is not encoded as a constructed type.
+     *
+     * Without the check `22 01 01` decodes as INTEGER 1 and `21 01 FF` as BOOLEAN TRUE, so one certificate has
+     * many byte-distinct encodings that all parse to the same object. Types that carry a value of their own
+     * check the encoding form in their own decoder; the string types are left out because BER allows them to be
+     * constructed, and `ConstructedString` handles those.
+     *
+     * @param int $tag Universal type tag
+     * @param bool $constructed Whether the constructed bit is set
+     */
+    protected static function checkUniversalEncodingForm(int $tag, bool $constructed): void
+    {
+        if ($constructed && in_array($tag, self::PRIMITIVE_ONLY_TYPES, true)) {
+            throw new DecodeException(sprintf('%s must be encoded as a primitive type.', self::tagToName($tag)));
+        }
     }
 
     /**

--- a/src/ASN1/Type/Primitive/BitString.php
+++ b/src/ASN1/Type/Primitive/BitString.php
@@ -174,6 +174,10 @@ final class BitString extends BaseString
             throw new DecodeException('Unused bits in a bit string must be less than 8.');
         }
         $str_len = $length - 1;
+        if ($str_len === 0 && $unused_bits !== 0) {
+            // there is no last octet to hold the unused bits, and numBits() would come back negative
+            throw new DecodeException('Empty bit string must have zero unused bits.');
+        }
         if ($str_len !== 0) {
             $str = mb_substr($data, $idx, $str_len, '8bit');
             if ($unused_bits !== 0) {

--- a/src/ASN1/Type/Primitive/Integer.php
+++ b/src/ASN1/Type/Primitive/Integer.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\ASN1\Type\Primitive;
 
 use Brick\Math\BigInteger;
+use Brick\Math\Exception\MathException;
 use function gettype;
 use InvalidArgumentException;
 use function is_int;
 use function is_scalar;
 use function is_string;
+use function mb_strlen;
+use function ord;
 use SpomkyLabs\Pki\ASN1\Component\Identifier;
 use SpomkyLabs\Pki\ASN1\Component\Length;
 use SpomkyLabs\Pki\ASN1\Element;
@@ -18,6 +21,7 @@ use SpomkyLabs\Pki\ASN1\Feature\ElementBase;
 use SpomkyLabs\Pki\ASN1\Type\PrimitiveType;
 use SpomkyLabs\Pki\ASN1\Type\UniversalClass;
 use SpomkyLabs\Pki\ASN1\Util\BigInt;
+use function sprintf;
 
 /**
  * Implements *INTEGER* type.
@@ -70,7 +74,14 @@ class Integer extends Element
      */
     public function intNumber(): int
     {
-        return $this->_number->toInt();
+        try {
+            return $this->_number->toInt();
+        } catch (MathException $e) {
+            // an arbitrary length integer is decoded happily, but a caller asking for an int is reading a field
+            // that has to fit in one. Letting brick/math's overflow exception escape would break the decoding
+            // contract of Element::fromDER() for every structure that reads a field this way.
+            throw new DecodeException(sprintf('Integer %s is too large.', $this->_number->base10()), 0, $e);
+        }
     }
 
     protected function encodedAsDER(): string
@@ -86,11 +97,30 @@ class Integer extends Element
             throw new DecodeException('Integer must have at least one content octet.');
         }
         $bytes = mb_substr($data, $idx, $length, '8bit');
+        self::checkMinimalEncoding($bytes);
         $idx += $length;
         $num = BigInt::fromSignedOctets($bytes)->getValue();
         $offset = $idx;
         // late static binding since enumerated extends integer type
         return static::create($num);
+    }
+
+    /**
+     * Check that the content octets are the minimal two's complement encoding of the value (X.690 sect. 8.3.2).
+     *
+     * Without the check `02 02 00 01` and `02 01 01` both decode to 1, so a signed structure has more than one
+     * valid encoding.
+     */
+    private static function checkMinimalEncoding(string $bytes): void
+    {
+        if (mb_strlen($bytes, '8bit') < 2) {
+            return;
+        }
+        $first = ord($bytes[0]);
+        $second = ord($bytes[1]);
+        if (($first === 0x00 && ($second & 0x80) === 0) || ($first === 0xFF && ($second & 0x80) !== 0)) {
+            throw new DecodeException('Integer value must be encoded in the minimum number of octets.');
+        }
     }
 
     /**
@@ -101,7 +131,7 @@ class Integer extends Element
         if (is_int($num)) {
             return true;
         }
-        if (is_string($num) && preg_match('/-?\d+/', $num) === 1) {
+        if (is_string($num) && preg_match('/\A-?\d+\z/', $num) === 1) {
             return true;
         }
         if ($num instanceof BigInteger) {

--- a/src/ASN1/Type/Primitive/Number.php
+++ b/src/ASN1/Type/Primitive/Number.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\ASN1\Type\Primitive;
 
 use Brick\Math\BigInteger;
+use Brick\Math\Exception\MathException;
 use function gettype;
 use InvalidArgumentException;
 use function is_int;
 use function is_scalar;
 use function is_string;
 use SpomkyLabs\Pki\ASN1\Element;
+use SpomkyLabs\Pki\ASN1\Exception\DecodeException;
 use SpomkyLabs\Pki\ASN1\Type\PrimitiveType;
 use SpomkyLabs\Pki\ASN1\Type\UniversalClass;
 use SpomkyLabs\Pki\ASN1\Util\BigInt;
@@ -62,7 +64,11 @@ abstract class Number extends Element
      */
     public function intNumber(): int
     {
-        return $this->number->toInt();
+        try {
+            return $this->number->toInt();
+        } catch (MathException $e) {
+            throw new DecodeException(sprintf('Number %s is too large.', $this->number->base10()), 0, $e);
+        }
     }
 
     protected function encodedAsDER(): string
@@ -78,7 +84,7 @@ abstract class Number extends Element
         if (is_int($num)) {
             return true;
         }
-        if (is_string($num) && preg_match('/-?\d+/', $num) === 1) {
+        if (is_string($num) && preg_match('/\A-?\d+\z/', $num) === 1) {
             return true;
         }
         if ($num instanceof BigInteger) {

--- a/src/ASN1/Type/Primitive/ObjectIdentifier.php
+++ b/src/ASN1/Type/Primitive/ObjectIdentifier.php
@@ -91,6 +91,10 @@ final class ObjectIdentifier extends Element
     {
         $idx = $offset;
         $len = Length::expectFromDER($data, $idx)->expectIntLength();
+        if ($len === 0) {
+            // an object identifier has at least one sub-identifier (X.690 sect. 8.19.1)
+            throw new DecodeException('Object identifier must have at least one content octet.');
+        }
         $subids = self::decodeSubIDs(mb_substr($data, $idx, $len, '8bit'));
         $idx += $len;
         // decode first subidentifier according to spec section 8.19.4
@@ -180,11 +184,17 @@ final class ObjectIdentifier extends Element
         $end = mb_strlen($data, '8bit');
         while ($idx < $end) {
             $num = BigInteger::of(0);
+            $first = true;
             while (true) {
                 if ($idx >= $end) {
                     throw new DecodeException('Unexpected end of data.');
                 }
                 $byte = ord($data[$idx++]);
+                // leading zero bits are not part of a minimal sub-identifier (X.690 sect. 8.19.2)
+                if ($first && $byte === 0x80) {
+                    throw new DecodeException('Leading zero octet in an object identifier sub-identifier.');
+                }
+                $first = false;
                 $num = $num->or($byte & 0x7F);
                 // bit 8 of the last octet is zero
                 if (0 === ($byte & 0x80)) {

--- a/src/ASN1/Type/Primitive/PrintableString.php
+++ b/src/ASN1/Type/Primitive/PrintableString.php
@@ -26,7 +26,8 @@ final class PrintableString extends PrimitiveString
 
     protected function validateString(string $string): bool
     {
-        $chars = preg_quote(" '()+,-./:=?]", '/');
+        // X.680 sect. 41, table 10: the PrintableString character set has no ']'
+        $chars = preg_quote(" '()+,-./:=?", '/');
         return preg_match('/[^A-Za-z0-9' . $chars . ']/', $string) !== 1;
     }
 }

--- a/src/ASN1/Type/Primitive/RelativeOID.php
+++ b/src/ASN1/Type/Primitive/RelativeOID.php
@@ -67,6 +67,9 @@ final class RelativeOID extends Element
     {
         $idx = $offset;
         $len = Length::expectFromDER($data, $idx)->expectIntLength();
+        if ($len === 0) {
+            throw new DecodeException('Relative object identifier must have at least one content octet.');
+        }
         $subids = self::decodeSubIDs(mb_substr($data, $idx, $len, '8bit'));
         $offset = $idx + $len;
         return self::create(self::implodeSubIDs(...$subids));
@@ -145,11 +148,17 @@ final class RelativeOID extends Element
         $end = mb_strlen($data, '8bit');
         while ($idx < $end) {
             $num = BigInteger::of(0);
+            $first = true;
             while (true) {
                 if ($idx >= $end) {
                     throw new DecodeException('Unexpected end of data.');
                 }
                 $byte = ord($data[$idx++]);
+                // leading zero bits are not part of a minimal sub-identifier (X.690 sect. 8.19.2)
+                if ($first && $byte === 0x80) {
+                    throw new DecodeException('Leading zero octet in an object identifier sub-identifier.');
+                }
+                $first = false;
                 $num = $num->or($byte & 0x7F);
                 // bit 8 of the last octet is zero
                 if (0 === ($byte & 0x80)) {

--- a/src/CryptoBridge/Crypto/OpenSSLCrypto.php
+++ b/src/CryptoBridge/Crypto/OpenSSLCrypto.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\CryptoBridge\Crypto;
 
 use function array_key_exists;
+use function function_exists;
 use function mb_strlen;
 use const OPENSSL_ALGO_MD4;
 use const OPENSSL_ALGO_MD5;
@@ -34,6 +35,13 @@ use UnexpectedValueException;
 final class OpenSSLCrypto extends Crypto
 {
     /**
+     * Whether this runtime's OpenSSL extension can verify each EdDSA algorithm, once it has been asked.
+     *
+     * @var array<string, bool>
+     */
+    private static array $opensslEdDSASupport = [];
+
+    /**
      * Mapping from algorithm OID to OpenSSL signature method identifier.
      *
      * @internal
@@ -61,6 +69,42 @@ final class OpenSSLCrypto extends Crypto
     ];
 
     /**
+     * The EdDSA signature algorithms, with what is needed to use and to probe for each of them.
+     *
+     * EdDSA is a one shot scheme: the message is not pre-hashed, so it does not fit the digest based API the
+     * other algorithms go through, and an OpenSSL extension that does not implement it reports every signature as
+     * invalid rather than saying so. `spki` and `signature` are RFC 8032's test vector for the empty message
+     * (sect. 7.1 test 1 and sect. 7.4 "Blank"), a known good pair this engine verifies once to find out whether
+     * the runtime can do the algorithm at all. Asking the runtime is more honest than comparing PHP_VERSION_ID,
+     * since the extension also has to be built against an OpenSSL that has the curve.
+     *
+     * @internal
+     *
+     * @var array<string, array{keyLength: int, signatureLength: int, spki: string, signature: string}>
+     */
+    private const MAP_EDDSA = [
+        AlgorithmIdentifier::OID_ED25519 => [
+            'keyLength' => 32,
+            'signatureLength' => 64,
+            'spki' => '302a300506032b6570032100' .
+                'd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a',
+            'signature' => 'e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e06522490155' .
+                '5fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b',
+        ],
+        AlgorithmIdentifier::OID_ED448 => [
+            'keyLength' => 57,
+            'signatureLength' => 114,
+            'spki' => '3043300506032b6571033a00' .
+                '5fd7449b59b461fd2ce787ec616ad46a1da1342485a70e1f8a0ea75d80e96778' .
+                'edf124769b46c7061bd6783df1e50f6cd1fa1abeafe8256180',
+            'signature' => '533a37f6bbe457251f023c0d88f976ae2dfb504a843e34d2074fd823d41a591f' .
+                '2b233f034f628281f2fd7a22ddd47d7828c59bd0a21bfd3980ff0d2028d4b18a' .
+                '9df63e006c5d1c2d345b925d8dc00b4104852db99ac5c7cdda8530a113a0f4db' .
+                'b61149f05a7363268c71d95808ff2e652600',
+        ],
+    ];
+
+    /**
      * Mapping from algorithm OID to OpenSSL cipher method name.
      *
      * @internal
@@ -81,6 +125,14 @@ final class OpenSSLCrypto extends Crypto
         SignatureAlgorithmIdentifier $algo
     ): Signature {
         $this->_checkSignatureAlgoAndKey($algo, $privkey_info->algorithmIdentifier());
+        if (array_key_exists($algo->oid(), self::MAP_EDDSA) && ! self::opensslSupportsEdDSA($algo->oid())) {
+            // ext-sodium could sign Ed25519, but it cannot produce an Ed448 signature and this is not the place
+            // to grow a second signing engine: say plainly that the runtime cannot do it.
+            throw new UnexpectedValueException(sprintf(
+                '%s signing is not supported by this PHP runtime.',
+                $algo->name()
+            ));
+        }
         $result = openssl_sign($data, $signature, (string) $privkey_info->toPEM(), $this->_algoToDigest($algo));
         if ($result === false) {
             throw new RuntimeException('openssl_sign() failed: ' . $this->_getLastError());
@@ -95,6 +147,9 @@ final class OpenSSLCrypto extends Crypto
         SignatureAlgorithmIdentifier $algo
     ): bool {
         $this->_checkSignatureAlgoAndKey($algo, $pubkey_info->algorithmIdentifier());
+        if (array_key_exists($algo->oid(), self::MAP_EDDSA)) {
+            return $this->verifyEdDSA($data, $signature, $pubkey_info, $algo);
+        }
         $result = openssl_verify(
             $data,
             $signature->bitString()
@@ -176,10 +231,88 @@ final class OpenSSLCrypto extends Crypto
 
     /**
      * Check that given signature algorithm supports key of given type.
-     *
-     * @param SignatureAlgorithmIdentifier $sig_algo Signature algorithm
-     * @param AlgorithmIdentifier $key_algo Key algorithm
      */
+    /**
+     * Whether this engine can check a signature made with the given algorithm.
+     *
+     * PathValidationConfig advertises Ed25519 and Ed448 in its default allowed set, but whether they can actually
+     * be checked depends on the runtime. An application that would rather refuse a chain up front than have it
+     * fail closed during validation can narrow the configured set with this.
+     */
+    public function supportsSignatureAlgorithm(SignatureAlgorithmIdentifier $algo): bool
+    {
+        $oid = $algo->oid();
+        if (array_key_exists($oid, self::MAP_EDDSA)) {
+            return self::opensslSupportsEdDSA($oid)
+                || ($oid === AlgorithmIdentifier::OID_ED25519
+                    && function_exists('sodium_crypto_sign_verify_detached'));
+        }
+        return array_key_exists($oid, self::MAP_DIGEST_OID);
+    }
+
+    /**
+     * Verify an EdDSA signature.
+     *
+     * PHP 8.5 verifies it through openssl_verify() with 0 as the digest method. Older runtimes have no EdDSA in
+     * the OpenSSL extension at all, so Ed25519 goes through ext-sodium, which has been bundled since PHP 7.2.
+     */
+    private function verifyEdDSA(
+        string $data,
+        Signature $signature,
+        PublicKeyInfo $pubkey_info,
+        SignatureAlgorithmIdentifier $algo
+    ): bool {
+        $oid = $algo->oid();
+        $sig = $signature->bitString()
+            ->string();
+        if (self::opensslSupportsEdDSA($oid)) {
+            $result = openssl_verify($data, $sig, (string) $pubkey_info->toPEM(), 0);
+            if ($result === -1) {
+                throw new RuntimeException('openssl_verify() failed: ' . $this->_getLastError());
+            }
+            return $result === 1;
+        }
+        // ext-sodium has been bundled since PHP 7.2 and covers Ed25519. There is no equivalent for Ed448.
+        if ($oid === AlgorithmIdentifier::OID_ED25519
+            && function_exists('sodium_crypto_sign_verify_detached')) {
+            $key = $pubkey_info->publicKeyData()
+                ->string();
+            // sodium refuses a key or a signature of the wrong size with a TypeError rather than a false, and
+            // both come straight out of the certificate
+            if ($key === '' || $sig === '') {
+                return false;
+            }
+            if (mb_strlen($key, '8bit') !== self::MAP_EDDSA[$oid]['keyLength']
+                || mb_strlen($sig, '8bit') !== self::MAP_EDDSA[$oid]['signatureLength']) {
+                return false;
+            }
+            return sodium_crypto_sign_verify_detached($sig, $data, $key);
+        }
+        throw new UnexpectedValueException(sprintf(
+            '%s verification is not supported by this PHP runtime.',
+            $algo->name()
+        ));
+    }
+
+    /**
+     * Whether this runtime's OpenSSL extension can verify a signature made with the given EdDSA algorithm.
+     *
+     * Answered once per algorithm, by verifying RFC 8032's known good test vector for it. An extension without
+     * EdDSA reports the vector as invalid rather than raising, which is exactly the failure mode this guards
+     * against: the two curves are probed separately, since a runtime may well have one and not the other.
+     */
+    private static function opensslSupportsEdDSA(string $oid): bool
+    {
+        if (! array_key_exists($oid, self::$opensslEdDSASupport)) {
+            $pem = "-----BEGIN PUBLIC KEY-----\n" .
+                trim(chunk_split(base64_encode((string) hex2bin(self::MAP_EDDSA[$oid]['spki'])), 64, "\n")) .
+                "\n-----END PUBLIC KEY-----";
+            $signature = (string) hex2bin(self::MAP_EDDSA[$oid]['signature']);
+            self::$opensslEdDSASupport[$oid] = @openssl_verify('', $signature, $pem, 0) === 1;
+        }
+        return self::$opensslEdDSASupport[$oid];
+    }
+
     protected function _checkSignatureAlgoAndKey(
         SignatureAlgorithmIdentifier $sig_algo,
         AlgorithmIdentifier $key_algo

--- a/src/CryptoBridge/Crypto/OpenSSLCrypto.php
+++ b/src/CryptoBridge/Crypto/OpenSSLCrypto.php
@@ -53,6 +53,11 @@ final class OpenSSLCrypto extends Crypto
         AlgorithmIdentifier::OID_ECDSA_WITH_SHA256 => OPENSSL_ALGO_SHA256,
         AlgorithmIdentifier::OID_ECDSA_WITH_SHA384 => OPENSSL_ALGO_SHA384,
         AlgorithmIdentifier::OID_ECDSA_WITH_SHA512 => OPENSSL_ALGO_SHA512,
+        // EdDSA is a one shot signature scheme: the message is not pre-hashed, and OpenSSL takes 0 as the digest
+        // method. Without these two entries a chain that `openssl verify` accepts could not be verified at all,
+        // while PathValidationConfig advertises both algorithms in its default allow list.
+        AlgorithmIdentifier::OID_ED25519 => 0,
+        AlgorithmIdentifier::OID_ED448 => 0,
     ];
 
     /**

--- a/src/CryptoEncoding/PEM.php
+++ b/src/CryptoEncoding/PEM.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\CryptoEncoding;
 
 use function is_string;
+use function mb_strlen;
 use RuntimeException;
 use Stringable;
 use UnexpectedValueException;
@@ -50,7 +51,7 @@ final class PEM implements Stringable
         /* line start */
         '(?:^|[\r\n])' .
         /* header */
-        '-----BEGIN (.+?)-----[\r\n]+' .
+        '-----BEGIN ([A-Za-z0-9][A-Za-z0-9 ]*)-----[\r\n]+' .
         /* payload */
         '(.+?)' .
         /* trailer */
@@ -87,6 +88,11 @@ final class PEM implements Stringable
         }
         $payload = preg_replace('/\s+/', '', $match[2]);
         if (! is_string($payload)) {
+            throw new UnexpectedValueException('Failed to decode PEM data.');
+        }
+        // base64_decode() is strict about the alphabet but not about padding, so a blob that OpenSSL refuses
+        // would otherwise be accepted here (RFC 7468 sect. 3 requires the padded alphabet of RFC 4648)
+        if (mb_strlen($payload, '8bit') % 4 !== 0) {
             throw new UnexpectedValueException('Failed to decode PEM data.');
         }
         $data = base64_decode($payload, true);

--- a/src/X501/ASN1/Attribute.php
+++ b/src/X501/ASN1/Attribute.php
@@ -144,7 +144,9 @@ final class Attribute implements Countable, IteratorAggregate
             },
             $this->values
         );
-        return self::fromAttributeValues(...$values);
+        // the attribute type is carried by the attribute itself: deriving it from the first value would refuse an
+        // attribute with an empty value set, which the encoding permits and OpenSSL emits
+        return self::create($this->type, ...$values);
     }
 
     /**

--- a/src/X501/ASN1/RDN.php
+++ b/src/X501/ASN1/RDN.php
@@ -108,17 +108,21 @@ final class RDN implements Countable, IteratorAggregate, Stringable
         if (count($this) !== count($other)) {
             return false;
         }
-        $attribs1 = $this->_attribs;
-        $attribs2 = $other->_attribs;
-        // if there's multiple attributes, sort using SET OF rules
-        if (count($attribs1) > 1) {
-            $attribs1 = self::fromASN1($this->toASN1())->_attribs;
-            $attribs2 = self::fromASN1($other->toASN1())->_attribs;
-        }
-        for ($i = count($attribs1) - 1; $i >= 0; --$i) {
-            $tv1 = $attribs1[$i];
-            $tv2 = $attribs2[$i];
-            if (! $tv1->equals($tv2)) {
+        // RFC 5280 sect. 7.1: an RDN is a SET, so two of them are equal when their attributes match as a multiset,
+        // whatever the order. Sorting both sides in DER order and comparing position by position gets this wrong,
+        // because the attribute values compare case insensitively while the DER sort does not: RDN{cn=a,cn=B} and
+        // RDN{cn=A,cn=b} sort the other way round and were reported as different.
+        $unmatched = $other->_attribs;
+        foreach ($this->_attribs as $tv1) {
+            $matched = false;
+            foreach ($unmatched as $idx => $tv2) {
+                if ($tv1->equals($tv2)) {
+                    unset($unmatched[$idx]);
+                    $matched = true;
+                    break;
+                }
+            }
+            if (! $matched) {
                 return false;
             }
         }

--- a/src/X509/AttributeCertificate/AttributeCertificate.php
+++ b/src/X509/AttributeCertificate/AttributeCertificate.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\Pki\X509\AttributeCertificate;
 
+use RuntimeException;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\CryptoBridge\Crypto;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
@@ -194,6 +195,14 @@ final class AttributeCertificate implements Stringable
         // option, and the correct one.
         $data = $this->acInfoDER ?? $this->acInfo->toASN1()
             ->toDER();
-        return $crypto->verify($data, $this->signatureValue, $pubkey_info, $this->signatureAlgorithm);
+        // a bool returning predicate must not throw on a signature it cannot check: the algorithm is named by
+        // the certificate, so an attacker picks it, and `if (! $cert->verify($key))` in application code would
+        // otherwise become an unhandled fatal. An unsupported algorithm, a key the algorithm does not match and
+        // an engine level failure all mean the same thing to the caller: the signature was not verified.
+        try {
+            return $crypto->verify($data, $this->signatureValue, $pubkey_info, $this->signatureAlgorithm);
+        } catch (RuntimeException|UnexpectedValueException) {
+            return false;
+        }
     }
 }

--- a/src/X509/AttributeCertificate/Validation/ACValidationConfig.php
+++ b/src/X509/AttributeCertificate/Validation/ACValidationConfig.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\X509\AttributeCertificate\Validation;
 
 use DateTimeImmutable;
+use SpomkyLabs\Pki\X509\Certificate\Certificate;
+use SpomkyLabs\Pki\X509\Certificate\CertificateBundle;
 use SpomkyLabs\Pki\X509\Certificate\Extension\Target\Target;
 use SpomkyLabs\Pki\X509\CertificationPath\CertificationPath;
 use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationConfig;
@@ -15,9 +17,20 @@ use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationConfig;
 final class ACValidationConfig
 {
     /**
-     * Evaluation reference time.
+     * Evaluation reference time, or null to resolve it on every evaluation.
      */
-    private DateTimeImmutable $evalTime;
+    private ?DateTimeImmutable $evalTime;
+
+    /**
+     * Certificates of the attribute authorities the caller directly trusts, or null when the caller takes
+     * responsibility for RFC 5755 sect. 5 check 4 itself.
+     */
+    private ?CertificateBundle $trustedAttributeAuthorities;
+
+    /**
+     * Whether the caller supplied the path validation configuration.
+     */
+    private bool $pathValidationConfigProvided;
 
     /**
      * Permitted targets.
@@ -39,9 +52,14 @@ final class ACValidationConfig
         private readonly CertificationPath $holderPath,
         private readonly CertificationPath $issuerPath
     ) {
-        $this->evalTime = new DateTimeImmutable();
+        // resolved on every evaluation rather than snapshotted here: a config object shared by a DI container or
+        // held across requests in a worker runtime would otherwise keep validating expired credentials and
+        // expired certificates for the lifetime of the process
+        $this->evalTime = null;
         $this->targets = [];
+        $this->trustedAttributeAuthorities = null;
         $this->pathValidationConfig = PathValidationConfig::defaultConfig();
+        $this->pathValidationConfigProvided = false;
     }
 
     public static function create(CertificationPath $holderPath, CertificationPath $issuerPath): self
@@ -76,6 +94,7 @@ final class ACValidationConfig
     {
         $obj = clone $this;
         $obj->pathValidationConfig = $config;
+        $obj->pathValidationConfigProvided = true;
         return $obj;
     }
 
@@ -85,6 +104,17 @@ final class ACValidationConfig
     public function pathValidationConfig(): PathValidationConfig
     {
         return $this->pathValidationConfig;
+    }
+
+    /**
+     * Whether the caller supplied the path validation configuration.
+     *
+     * The validator derives a maximum path length from the length of the path it was handed when the caller did
+     * not, and leaves the caller's own limit alone when they did.
+     */
+    public function hasPathValidationConfig(): bool
+    {
+        return $this->pathValidationConfigProvided;
     }
 
     /**
@@ -99,10 +129,38 @@ final class ACValidationConfig
 
     /**
      * Get the evaluation reference time.
+     *
+     * Unless withEvaluationTime() pinned it, this is the instant the call is made rather than the instant this
+     * object was built.
      */
     public function evaluationTime(): DateTimeImmutable
     {
-        return $this->evalTime;
+        return $this->evalTime ?? new DateTimeImmutable();
+    }
+
+    /**
+     * Get self with the attribute authorities that are directly trusted to issue attribute certificates.
+     *
+     * RFC 5755 sect. 5 check 4 requires the AC issuer to be directly trusted as an attribute authority. Without
+     * this list the validator accepts whatever end-entity certificate the issuer path ends in, so a caller who
+     * locates the attribute authority by matching the issuer name against a bundle turns every end-entity
+     * certificate under the trust anchor into an attribute authority.
+     *
+     * @param Certificate ...$certs Certificates of the trusted attribute authorities
+     */
+    public function withTrustedAttributeAuthorities(Certificate ...$certs): self
+    {
+        $obj = clone $this;
+        $obj->trustedAttributeAuthorities = CertificateBundle::create(...$certs);
+        return $obj;
+    }
+
+    /**
+     * Get the attribute authorities that are directly trusted, or null when the caller has not named any.
+     */
+    public function trustedAttributeAuthorities(): ?CertificateBundle
+    {
+        return $this->trustedAttributeAuthorities;
     }
 
     /**

--- a/src/X509/AttributeCertificate/Validation/ACValidator.php
+++ b/src/X509/AttributeCertificate/Validation/ACValidator.php
@@ -12,10 +12,17 @@ use SpomkyLabs\Pki\X509\Certificate\Certificate;
 use SpomkyLabs\Pki\X509\Certificate\Extension\Extension;
 use SpomkyLabs\Pki\X509\Certificate\Extension\Target\Targets;
 use SpomkyLabs\Pki\X509\Certificate\Extension\TargetInformationExtension;
+use SpomkyLabs\Pki\X509\CertificationPath\CertificationPath;
 use SpomkyLabs\Pki\X509\CertificationPath\Exception\PathValidationException;
+use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationConfig;
 
 /**
  * Implements attribute certificate validation conforming to RFC 5755.
+ *
+ * RFC 5755 sect. 5 check 4 requires the AC issuer to be directly trusted as an attribute authority. Name the
+ * trusted authorities with ACValidationConfig::withTrustedAttributeAuthorities() to have that check run here;
+ * without it the check is the caller's responsibility, and this validator only establishes that the issuer
+ * certificate chains to the trust anchor and carries a profile that permits signing.
  *
  * @see https://tools.ietf.org/html/rfc5755#section-5
  */
@@ -70,9 +77,7 @@ final class ACValidator
     private function validateHolder(): Certificate
     {
         $path = $this->config->holderPath();
-        $config = $this->config->pathValidationConfig()
-            ->withMaxLength(count($path))
-            ->withDateTime($this->config->evaluationTime());
+        $config = $this->pathConfigFor($path);
         try {
             $holder = $path->validate($config, $this->crypto)
                 ->certificate();
@@ -93,9 +98,7 @@ final class ACValidator
     private function verifyIssuer(): Certificate
     {
         $path = $this->config->issuerPath();
-        $config = $this->config->pathValidationConfig()
-            ->withMaxLength(count($path))
-            ->withDateTime($this->config->evaluationTime());
+        $config = $this->pathConfigFor($path);
         try {
             $issuer = $path->validate($config, $this->crypto)
                 ->certificate();
@@ -114,6 +117,23 @@ final class ACValidator
     }
 
     /**
+     * Get the path validation configuration to use for one of the two certification paths.
+     *
+     * The maximum path length is derived from the path itself only when the caller did not supply a
+     * configuration of their own: overriding it unconditionally made PathValidationConfig::maxLength() a no-op
+     * for both paths, so a caller who set a limit did not get it.
+     */
+    private function pathConfigFor(CertificationPath $path): PathValidationConfig
+    {
+        $config = $this->config->pathValidationConfig()
+            ->withDateTime($this->config->evaluationTime());
+        if (! $this->config->hasPathValidationConfig()) {
+            $config = $config->withMaxLength(count($path));
+        }
+        return $config;
+    }
+
+    /**
      * Validate AC issuer's profile.
      *
      * @see https://tools.ietf.org/html/rfc5755#section-4.5
@@ -122,7 +142,12 @@ final class ACValidator
     {
         $exts = $cert->tbsCertificate()
             ->extensions();
-        if ($exts->hasKeyUsage() && ! $exts->keyUsage()->isDigitalSignature()) {
+        // sect. 4.5 permits either bit: an attribute authority that asserts non-repudiation only is conforming
+        if ($exts->hasKeyUsage()
+            && ! $exts->keyUsage()
+                ->isDigitalSignature()
+            && ! $exts->keyUsage()
+                ->isNonRepudiation()) {
             throw new ACValidationException(
                 "Issuer PKC's Key Usage extension doesn't permit" .
                 ' verification of digital signatures.'
@@ -130,6 +155,11 @@ final class ACValidator
         }
         if ($exts->hasBasicConstraints() && $exts->basicConstraints()->isCA()) {
             throw new ACValidationException('Issuer PKC must not be a CA.');
+        }
+        // RFC 5755 sect. 5, check 4: the AC issuer must be directly trusted as an attribute authority
+        $authorities = $this->config->trustedAttributeAuthorities();
+        if ($authorities !== null && ! $authorities->contains($cert)) {
+            throw new ACValidationException('Issuer PKC is not a trusted attribute authority.');
         }
     }
 

--- a/src/X509/Certificate/Certificate.php
+++ b/src/X509/Certificate/Certificate.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\Pki\X509\Certificate;
 
+use RuntimeException;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\CryptoBridge\Crypto;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
@@ -136,11 +137,31 @@ final class Certificate implements Stringable
     }
 
     /**
-     * Check whether certificate is semantically equal to another.
+     * Check whether this is the very same certificate as another, comparing the encodings octet by octet.
+     *
+     * The comparison used to be on the serial number, the key identifier of the subject public key and the subject
+     * DN alone, which are three public values an attacker is free to repeat: a certificate agreeing on them but
+     * differing in issuer, validity, every extension and the signature was reported as the same certificate, and
+     * `CertificateBundle::contains()` answered "yes" for a certificate that was not in the bundle.
      *
      * @param Certificate $cert Certificate to compare to
      */
     public function equals(self $cert): bool
+    {
+        return hash_equals($this->toDER(), $cert->toDER());
+    }
+
+    /**
+     * Check whether the certificate names the same subject, holding the same key, with the same serial number.
+     *
+     * This is not an identity check: two certificates may agree on all three and still be issued by different
+     * issuers, carry different extensions and be signed by different keys. Use `equals()` to answer "is this the
+     * certificate I have", and this predicate only to group certificates that were issued for the same subject
+     * key, such as a re-issued certificate and the one it replaces.
+     *
+     * @param Certificate $cert Certificate to compare to
+     */
+    public function hasEqualSubjectIdentity(self $cert): bool
     {
         return $this->_hasEqualSerialNumber($cert) &&
             $this->_hasEqualPublicKey($cert) && $this->_hasEqualSubject($cert);
@@ -190,7 +211,15 @@ final class Certificate implements Stringable
         // the correct one.
         $data = $this->tbsCertificateDER ?? $this->tbsCertificate->toASN1()
             ->toDER();
-        return $crypto->verify($data, $this->signatureValue, $pubkey_info, $this->signatureAlgorithm);
+        // a bool returning predicate must not throw on a signature it cannot check: the algorithm is named by
+        // the certificate, so an attacker picks it, and `if (! $cert->verify($key))` in application code would
+        // otherwise become an unhandled fatal. An unsupported algorithm, a key the algorithm does not match and
+        // an engine level failure all mean the same thing to the caller: the signature was not verified.
+        try {
+            return $crypto->verify($data, $this->signatureValue, $pubkey_info, $this->signatureAlgorithm);
+        } catch (RuntimeException|UnexpectedValueException) {
+            return false;
+        }
     }
 
     /**

--- a/src/X509/Certificate/CertificateBundle.php
+++ b/src/X509/Certificate/CertificateBundle.php
@@ -107,7 +107,10 @@ final class CertificateBundle implements Countable, IteratorAggregate
      */
     public function contains(Certificate $cert): bool
     {
-        $id = self::_getCertKeyId($cert);
+        // the computed identifier is derived from the key itself, so a certificate is always registered under it
+        $id = $cert->tbsCertificate()
+            ->subjectPublicKeyInfo()
+            ->keyIdentifier();
         $map = $this->_getKeyIdMap();
         if (! isset($map[$id])) {
             return false;
@@ -124,6 +127,14 @@ final class CertificateBundle implements Countable, IteratorAggregate
     /**
      * Get all certificates that have given subject key identifier.
      *
+     * A certificate is indexed both under the identifier computed from its subjectPublicKeyInfo and under the one
+     * its subjectKeyIdentifier extension declares, when the two differ. The declared value is arbitrary data that
+     * is never checked against the key, so indexing on it alone let a single certificate whose extension repeats
+     * a real intermediate's identifier displace that intermediate and deny validation of a good chain.
+     *
+     * The certificates whose computed identifier matches come first, ahead of those that only claim the value, so
+     * a caller that takes the first match takes the one that actually holds the key.
+     *
      * @return Certificate[]
      */
     public function allBySubjectKeyIdentifier(string $id): array
@@ -132,7 +143,19 @@ final class CertificateBundle implements Countable, IteratorAggregate
         if (! isset($map[$id])) {
             return [];
         }
-        return $map[$id];
+        $computed = [];
+        $declared = [];
+        foreach ($map[$id] as $cert) {
+            $keyId = $cert->tbsCertificate()
+                ->subjectPublicKeyInfo()
+                ->keyIdentifier();
+            if ($keyId === $id) {
+                $computed[] = $cert;
+            } else {
+                $declared[] = $cert;
+            }
+        }
+        return array_merge($computed, $declared);
     }
 
     /**
@@ -174,29 +197,41 @@ final class CertificateBundle implements Countable, IteratorAggregate
         if (! isset($this->keyIdMap)) {
             $this->keyIdMap = [];
             foreach ($this->certs as $cert) {
-                $id = self::_getCertKeyId($cert);
-                if (! isset($this->keyIdMap[$id])) {
-                    $this->keyIdMap[$id] = [];
+                foreach (self::_getCertKeyIds($cert) as $id) {
+                    if (! isset($this->keyIdMap[$id])) {
+                        $this->keyIdMap[$id] = [];
+                    }
+                    $this->keyIdMap[$id][] = $cert;
                 }
-                array_push($this->keyIdMap[$id], $cert);
             }
         }
         return $this->keyIdMap;
     }
 
     /**
-     * Get public key id for the certificate.
+     * Get the public key ids the certificate is to be indexed under.
+     *
+     * The identifier computed from the subjectPublicKeyInfo comes first: it is derived from the key and cannot be
+     * chosen. The subjectKeyIdentifier extension is added alongside it, so a lookup on the value another
+     * certificate's authorityKeyIdentifier declares still finds this one, without letting that claim be the only
+     * way the certificate can be found.
+     *
+     * @return list<string>
      */
-    private static function _getCertKeyId(Certificate $cert): string
+    private static function _getCertKeyIds(Certificate $cert): array
     {
+        $ids = [$cert->tbsCertificate()
+            ->subjectPublicKeyInfo()
+            ->keyIdentifier()];
         $exts = $cert->tbsCertificate()
             ->extensions();
         if ($exts->hasSubjectKeyIdentifier()) {
-            return $exts->subjectKeyIdentifier()
+            $declared = $exts->subjectKeyIdentifier()
                 ->keyIdentifier();
+            if ($declared !== $ids[0]) {
+                $ids[] = $declared;
+            }
         }
-        return $cert->tbsCertificate()
-            ->subjectPublicKeyInfo()
-            ->keyIdentifier();
+        return $ids;
     }
 }

--- a/src/X509/Certificate/Extension/Extension.php
+++ b/src/X509/Certificate/Extension/Extension.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\X509\Certificate\Extension;
 
 use function array_key_exists;
+use function count;
 use SpomkyLabs\Pki\ASN1\Element;
+use SpomkyLabs\Pki\ASN1\Exception\DecodeException;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\Boolean;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\ObjectIdentifier;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\OctetString;
+use function sprintf;
 use Stringable;
 
 /**
@@ -245,6 +248,12 @@ abstract class Extension implements Stringable
     public static function fromASN1(Sequence $seq): self
     {
         $idx = 0;
+        // an Extension is two or three elements; without the check a truncated SEQUENCE reaches Structure::at()
+        // and raises an OutOfBoundsException instead of a decoding failure
+        $count = count($seq);
+        if ($count < 2 || $count > 3) {
+            throw new DecodeException(sprintf('Extension must have 2 or 3 elements, got %d.', $count));
+        }
         $extnID = $seq->at($idx++)
             ->asObjectIdentifier()
             ->oid();

--- a/src/X509/Certificate/TBSCertificate.php
+++ b/src/X509/Certificate/TBSCertificate.php
@@ -8,6 +8,7 @@ use Brick\Math\BigInteger;
 use function chr;
 use function count;
 use const E_USER_DEPRECATED;
+use function func_num_args;
 use function implode;
 use function in_array;
 use InvalidArgumentException;
@@ -29,6 +30,7 @@ use SpomkyLabs\Pki\X501\ASN1\Name;
 use SpomkyLabs\Pki\X509\Certificate\Extension\AuthorityKeyIdentifierExtension;
 use SpomkyLabs\Pki\X509\Certificate\Extension\Extension;
 use SpomkyLabs\Pki\X509\Certificate\Extension\SubjectKeyIdentifierExtension;
+use SpomkyLabs\Pki\X509\Certificate\Extension\UnknownExtension;
 use SpomkyLabs\Pki\X509\CertificationRequest\CertificationRequest;
 use function sprintf;
 use function strval;
@@ -203,7 +205,17 @@ final class TBSCertificate
      * The extensions a request asks for are chosen by the requester. Those in FORBIDDEN_CSR_EXTENSIONS decide
      * what a certificate is allowed to do, so they are never copied: a requester asking for basicConstraints
      * cA:TRUE and keyUsage keyCertSign is asking to become a certificate authority. The issuer sets those
-     * itself. Every other requested extension is copied, unless $allowedExtensionOids narrows the set further.
+     * itself.
+     *
+     * Name the extensions to copy in $allowedExtensionOids. Leaving the argument out copies every requested
+     * extension that is not forbidden, which is a deny list: the set of extensions that matter grows over time
+     * and every future one would be copied by default. A request can currently carry a subjectAltName naming an
+     * identity the subject DN says nothing about, or an authorityInformationAccess choosing the OCSP responder a
+     * relying party will ask. That default is deprecated and becomes the empty allow list in the next major
+     * release; pass null explicitly to ask for it.
+     *
+     * An unknown extension marked critical is never copied, whatever the allow list says: it would be signed
+     * verbatim and then no RFC 5280 validator would accept the certificate, this library's own included.
      *
      * Note that signature is not verified and must be done by the caller.
      *
@@ -213,6 +225,7 @@ final class TBSCertificate
      */
     public static function fromCSR(CertificationRequest $cr, ?array $allowedExtensionOids = null): self
     {
+        $allowListGiven = func_num_args() > 1;
         if ($allowedExtensionOids !== null) {
             $forbidden = array_intersect($allowedExtensionOids, self::FORBIDDEN_CSR_EXTENSIONS);
             if (count($forbidden) !== 0) {
@@ -244,7 +257,21 @@ final class TBSCertificate
                     if ($allowedExtensionOids !== null && ! in_array($oid, $allowedExtensionOids, true)) {
                         continue;
                     }
+                    // an extension this library cannot even parse, signed as critical, produces a certificate
+                    // that is dead on arrival: no conforming validator will accept it
+                    if ($extension->isCritical() && $extension instanceof UnknownExtension) {
+                        continue;
+                    }
                     $accepted[] = $extension;
+                }
+                if (! $allowListGiven && count($accepted) !== 0) {
+                    @trigger_error(sprintf(
+                        'Copying requested extensions from a certification request without naming them is '
+                        . 'deprecated and will stop copying anything in the next major release. %s '
+                        . 'were taken from the request. Pass the OIDs to copy as the second argument of '
+                        . 'fromCSR(), or pass null explicitly to keep the current behaviour.',
+                        implode(', ', array_map(static fn (Extension $e) => $e->oid(), $accepted))
+                    ), E_USER_DEPRECATED);
                 }
                 $tbs_cert = $tbs_cert->withExtensions(Extensions::create(...$accepted));
             }

--- a/src/X509/CertificationPath/CertificationPath.php
+++ b/src/X509/CertificationPath/CertificationPath.php
@@ -7,6 +7,7 @@ namespace SpomkyLabs\Pki\X509\CertificationPath;
 use ArrayIterator;
 use function count;
 use Countable;
+use const E_USER_DEPRECATED;
 use IteratorAggregate;
 use LogicException;
 use SpomkyLabs\Pki\CryptoBridge\Crypto;
@@ -45,6 +46,13 @@ final class CertificationPath implements Countable, IteratorAggregate
     private bool $fromPeerSuppliedChain = false;
 
     /**
+     * Whether the path's first certificate came out of a trust list the application supplied.
+     *
+     * Such a head is a trust anchor the application chose, so validating against it is sound and needs no warning.
+     */
+    private bool $anchoredInTrustList = false;
+
+    /**
      * @param Certificate ...$certificates Certificates from the trust anchor
      * to the target end-entity certificate
      */
@@ -64,6 +72,19 @@ final class CertificationPath implements Countable, IteratorAggregate
     public static function create(Certificate ...$certificates): self
     {
         return new self(...$certificates);
+    }
+
+    /**
+     * Initialize from certificates whose first one came out of a trust list the application supplied.
+     *
+     * @internal Used by CertificationPathBuilder, which only ever heads a path with a certificate taken from the
+     * trust list it was given.
+     */
+    public static function fromTrustList(Certificate ...$certificates): self
+    {
+        $path = self::create(...$certificates);
+        $path->anchoredInTrustList = true;
+        return $path;
     }
 
     /**
@@ -187,12 +208,27 @@ final class CertificationPath implements Countable, IteratorAggregate
      */
     public function validate(PathValidationConfig $config, ?Crypto $crypto = null): PathValidationResult
     {
-        if ($this->fromPeerSuppliedChain && ! $config->hasTrustAnchor()) {
-            throw new PathValidationException(
-                'The path was built from a peer-supplied certificate chain, so its first certificate cannot serve as '
-                . 'the trust anchor. Set one with PathValidationConfig::withTrustAnchor(), or build the path with '
-                . 'CertificationPath::toTarget() from a bundle of trusted certificates.'
-            );
+        if (! $config->hasTrustAnchor()) {
+            if ($this->fromPeerSuppliedChain) {
+                throw new PathValidationException(
+                    'The path was built from a peer-supplied certificate chain, so its first certificate cannot '
+                    . 'serve as the trust anchor. Set one with PathValidationConfig::withTrustAnchor(), or build '
+                    . 'the path with CertificationPath::toTarget() from a bundle of trusted certificates.'
+                );
+            }
+            if (! $this->anchoredInTrustList) {
+                // The guard above is attached to the constructor that was used rather than to the invariant it
+                // protects, and create() is the constructor an integrator reaches for first. Nothing in the
+                // result tells a chain anchored in the caller's trust store from one anchored in the attacker's,
+                // so the fallback is announced here and will be removed in the next major release.
+                @trigger_error(
+                    'Validating a certification path without an explicit trust anchor is deprecated and will '
+                    . 'throw in the next major release. The first certificate of the path is being used as the '
+                    . 'trust anchor. Name the anchor with PathValidationConfig::withTrustAnchor(), or build the '
+                    . 'path with CertificationPath::toTarget() from a bundle of trusted certificates.',
+                    E_USER_DEPRECATED
+                );
+            }
         }
         $crypto ??= Crypto::getDefault();
         return PathValidator::create($crypto, $config, ...$this->certificates)->validate();

--- a/src/X509/CertificationPath/PathBuilding/CertificationPathBuilder.php
+++ b/src/X509/CertificationPath/PathBuilding/CertificationPathBuilder.php
@@ -56,8 +56,9 @@ final class CertificationPathBuilder
     public function allPathsToTarget(Certificate $target, ?CertificateBundle $intermediate = null): array
     {
         $paths = $this->resolvePathsToTarget($target, $intermediate);
-        // map paths to CertificationPath objects
-        return array_map(static fn ($certs) => CertificationPath::create(...$certs), $paths);
+        // every path is headed by a certificate taken from the trust list this builder was given, so its head is
+        // a trust anchor the application chose
+        return array_map(static fn ($certs) => CertificationPath::fromTrustList(...$certs), $paths);
     }
 
     /**
@@ -74,7 +75,10 @@ final class CertificationPathBuilder
         if (count($paths) === 0) {
             throw new PathBuildingException('No certification paths.');
         }
-        usort($paths, fn ($a, $b) => count($a) < count($b) ? -1 : 1);
+        // a comparison that never returns 0 leaves the order among equal length paths to PHP's sort; the
+        // spaceship operator makes the choice deterministic instead. When more than one path is possible, use
+        // allPathsToTarget() and validate them in turn rather than committing to this one.
+        usort($paths, static fn ($a, $b) => count($a) <=> count($b));
         return reset($paths);
     }
 
@@ -88,21 +92,30 @@ final class CertificationPathBuilder
      */
     private function findIssuers(Certificate $target, CertificateBundle $bundle): array
     {
-        $issuers = [];
         $issuer_name = $target->tbsCertificate()
             ->issuer();
         $extensions = $target->tbsCertificate()
             ->extensions();
         // find by authority key identifier
+        $candidates = [];
         if ($extensions->hasAuthorityKeyIdentifier()) {
             $ext = $extensions->authorityKeyIdentifier();
             if ($ext->hasKeyIdentifier()) {
-                foreach ($bundle->allBySubjectKeyIdentifier($ext->keyIdentifier()) as $issuer) {
-                    // check that issuer name matches
-                    if ($issuer->tbsCertificate()->subject()->equals($issuer_name)) {
-                        $issuers[] = $issuer;
-                    }
-                }
+                $candidates = $bundle->allBySubjectKeyIdentifier($ext->keyIdentifier());
+            }
+        }
+        if (count($candidates) === 0) {
+            // RFC 5280 requires the authority key identifier on a CA-issued certificate, but plenty of real
+            // certificates omit it and the issuer name identifies the issuer on its own. Without the fallback
+            // such a certificate can never be chained, which pushes integrators towards CertificationPath's
+            // unsafe constructor. RFC 4158 sect. 3.5.12 expects a builder to match on the name.
+            $candidates = $bundle->all();
+        }
+        $issuers = [];
+        foreach ($candidates as $issuer) {
+            // check that issuer name matches
+            if ($issuer->tbsCertificate()->subject()->equals($issuer_name)) {
+                $issuers[] = $issuer;
             }
         }
         return $issuers;

--- a/src/X509/CertificationPath/PathValidation/PathValidationConfig.php
+++ b/src/X509/CertificationPath/PathValidation/PathValidationConfig.php
@@ -35,6 +35,11 @@ final class PathValidationConfig
      * parameters have to be bound as well as the OID, since Certificate::fromASN1() only compares the OID of the
      * outer and the signed algorithm identifiers, which would leave a hash, MGF and salt length downgrade open.
      *
+     * Whether Ed25519 and Ed448 can actually be checked depends on the runtime: the OpenSSL extension only grew
+     * EdDSA recently, and ext-sodium covers Ed25519 alone. Validation fails closed where it cannot, and
+     * OpenSSLCrypto::supportsSignatureAlgorithm() answers the question up front for an application that would
+     * rather narrow this set than have a chain refused later.
+     *
      * @var string[]
      */
     public const DEFAULT_ALLOWED_SIGNATURE_ALGORITHMS = [

--- a/src/X509/CertificationPath/PathValidation/PathValidationConfig.php
+++ b/src/X509/CertificationPath/PathValidation/PathValidationConfig.php
@@ -30,6 +30,11 @@ final class PathValidationConfig
      * enterprise and device PKIs continue to rely on it, and cutting them off silently is not this library's
      * call to make. Use HARDENED_ALLOWED_SIGNATURE_ALGORITHMS to refuse it.
      *
+     * RSASSA-PSS is left out because it is not implemented: a PSS signed certificate is refused when it is
+     * parsed, so allowing the OID here advertised a capability that does not exist. When PSS is implemented the
+     * parameters have to be bound as well as the OID, since Certificate::fromASN1() only compares the OID of the
+     * outer and the signed algorithm identifiers, which would leave a hash, MGF and salt length downgrade open.
+     *
      * @var string[]
      */
     public const DEFAULT_ALLOWED_SIGNATURE_ALGORITHMS = [
@@ -38,7 +43,6 @@ final class PathValidationConfig
         AlgorithmIdentifier::OID_SHA256_WITH_RSA_ENCRYPTION,
         AlgorithmIdentifier::OID_SHA384_WITH_RSA_ENCRYPTION,
         AlgorithmIdentifier::OID_SHA512_WITH_RSA_ENCRYPTION,
-        AlgorithmIdentifier::OID_RSASSA_PSS_ENCRYPTION,
         AlgorithmIdentifier::OID_ECDSA_WITH_SHA1,
         AlgorithmIdentifier::OID_ECDSA_WITH_SHA224,
         AlgorithmIdentifier::OID_ECDSA_WITH_SHA256,
@@ -61,7 +65,6 @@ final class PathValidationConfig
         AlgorithmIdentifier::OID_SHA256_WITH_RSA_ENCRYPTION,
         AlgorithmIdentifier::OID_SHA384_WITH_RSA_ENCRYPTION,
         AlgorithmIdentifier::OID_SHA512_WITH_RSA_ENCRYPTION,
-        AlgorithmIdentifier::OID_RSASSA_PSS_ENCRYPTION,
         AlgorithmIdentifier::OID_ECDSA_WITH_SHA224,
         AlgorithmIdentifier::OID_ECDSA_WITH_SHA256,
         AlgorithmIdentifier::OID_ECDSA_WITH_SHA384,

--- a/src/X509/CertificationRequest/CertificationRequest.php
+++ b/src/X509/CertificationRequest/CertificationRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\Pki\X509\CertificationRequest;
 
+use RuntimeException;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\CryptoBridge\Crypto;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
@@ -157,6 +158,14 @@ final class CertificationRequest implements Stringable
         $data = $this->certificationRequestInfoDER ?? $this->certificationRequestInfo->toASN1()
             ->toDER();
         $pk_info = $this->certificationRequestInfo->subjectPKInfo();
-        return $crypto->verify($data, $this->signature, $pk_info, $this->signatureAlgorithm);
+        // a bool returning predicate must not throw on a signature it cannot check: the algorithm is named by
+        // the certificate, so an attacker picks it, and `if (! $cert->verify($key))` in application code would
+        // otherwise become an unhandled fatal. An unsupported algorithm, a key the algorithm does not match and
+        // an engine level failure all mean the same thing to the caller: the signature was not verified.
+        try {
+            return $crypto->verify($data, $this->signature, $pk_info, $this->signatureAlgorithm);
+        } catch (RuntimeException|UnexpectedValueException) {
+            return false;
+        }
     }
 }

--- a/tests/ASN1/Component/IdentifierDecodeTest.php
+++ b/tests/ASN1/Component/IdentifierDecodeTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\Test\ASN1\Component;
 
 use Brick\Math\BigInteger;
-use Brick\Math\Exception\IntegerOverflowException;
 use function chr;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -113,8 +112,10 @@ final class IdentifierDecodeTest extends TestCase
     #[Test]
     public function hugeIntTagOverflow()
     {
+        // a tag number that does not fit in an int is malformed input, not a math error the caller has to handle
         $der = "\x1f" . str_repeat("\xff", 100) . "\x7f";
-        $this->expectException(IntegerOverflowException::class);
+        $this->expectException(DecodeException::class);
+        $this->expectExceptionMessage('is too large');
         Identifier::fromDER($der)->intTag();
     }
 

--- a/tests/ASN1/ElementDecodeTest.php
+++ b/tests/ASN1/ElementDecodeTest.php
@@ -7,6 +7,7 @@ namespace SpomkyLabs\Pki\Test\ASN1;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SpomkyLabs\Pki\ASN1\Element;
+use SpomkyLabs\Pki\ASN1\Exception\DecodeException;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\Boolean;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\NullType;
 use UnexpectedValueException;
@@ -41,7 +42,8 @@ final class ElementDecodeTest extends TestCase
     #[Test]
     public function unimplementedFail()
     {
-        $this->expectException(UnexpectedValueException::class);
+        // an universal tag this library does not implement is malformed input as far as the caller is concerned
+        $this->expectException(DecodeException::class);
         $this->expectExceptionMessage('not implemented');
         Element::fromDER("\x1f\x7f\x0");
     }

--- a/tests/ASN1/Regression/ConformanceDetailsTest.php
+++ b/tests/ASN1/Regression/ConformanceDetailsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\ASN1\Regression;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\ASN1\Element;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\PrintableString;
+use SpomkyLabs\Pki\CryptoEncoding\PEM;
+use function sprintf;
+use UnexpectedValueException;
+
+/**
+ * Small conformance gaps that were each inert on their own.
+ *
+ * @internal
+ */
+final class ConformanceDetailsTest extends TestCase
+{
+    #[Test]
+    public function numberValidationIsAnchored(): void
+    {
+        // preg_match('/-?\d+/') matches anywhere in the subject, so the check was decorative and its error
+        // message misleading. Nothing escaped, because BigInt::create() caught the resulting failure.
+        foreach (['abc1def', '1; DROP', "1\nx"] as $subject) {
+            try {
+                Integer::create($subject);
+                static::fail(sprintf('Expected "%s" to be refused.', $subject));
+            } catch (InvalidArgumentException $e) {
+                static::assertStringContainsString('is not a valid number', $e->getMessage());
+            }
+        }
+
+        static::assertSame('12', Integer::create('12')->number());
+        static::assertSame('-12', Integer::create('-12')->number());
+    }
+
+    #[Test]
+    public function printableStringRefusesTheClosingBracket(): void
+    {
+        // X.680 sect. 41, table 10 has no ']' in the PrintableString character set, and other implementations
+        // reject "\x13\x01\x5d".
+        $this->expectException(InvalidArgumentException::class);
+        PrintableString::create(']');
+    }
+
+    #[Test]
+    public function printableStringStillAcceptsItsOwnCharacterSet(): void
+    {
+        $string = "Example Ltd. (test) 'x' +1,2-3/4:5=6?";
+
+        static::assertSame($string, PrintableString::create($string)->string());
+    }
+
+    #[Test]
+    public function pemRefusesUnpaddedBase64(): void
+    {
+        // base64_decode(..., true) is strict about the alphabet but not about padding, so a blob OpenSSL refuses
+        // was accepted here.
+        $payload = rtrim(base64_encode(str_repeat('A', 10)), '=');
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Failed to decode PEM data.');
+        PEM::fromString("-----BEGIN CERTIFICATE-----\n{$payload}\n-----END CERTIFICATE-----");
+    }
+
+    #[Test]
+    public function pemStillAcceptsPaddedBase64(): void
+    {
+        $payload = base64_encode(str_repeat('A', 10));
+        $pem = PEM::fromString("-----BEGIN CERTIFICATE-----\n{$payload}\n-----END CERTIFICATE-----");
+
+        static::assertSame(PEM::TYPE_CERTIFICATE, $pem->type());
+        static::assertSame(str_repeat('A', 10), $pem->data());
+    }
+
+    #[Test]
+    public function pemLabelIsAnchoredToASingleLine(): void
+    {
+        // The label group was (.+?) under /s, so type() could come back as "CERTIFICATE " or hold a newline.
+        // Every in-library consumer compares with !== and rejects, so this was inert.
+        $payload = base64_encode(str_repeat('A', 10));
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Not a PEM formatted string.');
+        PEM::fromString("-----BEGIN CERTIFICATE \n{$payload}\n-----END CERTIFICATE \n-----");
+    }
+
+    #[Test]
+    public function theOffsetIsWrittenBackWhenTheCallersVariableIsNull(): void
+    {
+        // fromDER() used isset() rather than func_num_args(), which contradicted the docblock: a caller looping
+        // on the offset would spin. SignedDER worked around it with $offset ?? 0.
+        $der = "\x02\x01\x01\x02\x01\x02";
+        $offset = null;
+
+        Element::fromDER($der, $offset);
+        static::assertSame(3, $offset);
+
+        Element::fromDER($der, $offset);
+        static::assertSame(6, $offset);
+    }
+}

--- a/tests/ASN1/Regression/DecoderExceptionContractTest.php
+++ b/tests/ASN1/Regression/DecoderExceptionContractTest.php
@@ -8,6 +8,7 @@ use Brick\Math\BigInteger;
 use function chr;
 use Exception;
 use Iterator;
+use function json_encode;
 use OutOfBoundsException;
 use const PHP_INT_MAX;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -16,11 +17,16 @@ use PHPUnit\Framework\TestCase;
 use SpomkyLabs\Pki\ASN1\Element;
 use SpomkyLabs\Pki\ASN1\Exception\DecodeException;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\Boolean;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\ObjectIdentifier;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\OctetString;
 use SpomkyLabs\Pki\ASN1\Type\Tagged\ExplicitlyTaggedType;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
 use SpomkyLabs\Pki\X509\Certificate\Certificate;
+use SpomkyLabs\Pki\X509\Certificate\Extension\Extension;
 use SpomkyLabs\Pki\X509\Certificate\TBSCertificate;
+use SpomkyLabs\Pki\X509\CertificationRequest\CertificationRequest;
 use function sprintf;
 use Throwable;
 use UnexpectedValueException;
@@ -134,6 +140,93 @@ final class DecoderExceptionContractTest extends TestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Unsupported certificate version');
         TBSCertificate::fromASN1($tbs);
+    }
+
+    /**
+     * @return Iterator<string, array{string}>
+     */
+    public static function offContractInputProvider(): Iterator
+    {
+        // Identifier::intTag() called BigInt::toInt() with no guard, the mirror image of the guard
+        // Length::intLength() already had, so 15 bytes reached every X.509 entry point.
+        yield 'tag number beyond PHP_INT_MAX' => ["\x30\x0d\x1f\x81\x81\x81\x81\x81\x81\x81\x81\x81\x81\x00\x00"];
+        // an universal tag this library does not implement used to raise an UnexpectedValueException
+        yield 'EXTERNAL, not implemented' => ["\x08\x01\x00"];
+        yield 'EMBEDDED PDV, not implemented' => ["\x0b\x01\x00"];
+        yield 'universal tag 14, not implemented' => ["\x0e\x01\x00"];
+        yield 'universal tag 15, not implemented' => ["\x0f\x01\x00"];
+        // Real raised an UnexpectedValueException on a bad decimal payload, and reached
+        // BigInt::fromSignedOctets('') on a binary REAL whose long form exponent length octet is zero
+        yield 'decimal REAL with a bad payload' => ["\x09\x02\x01\x41"];
+        yield 'binary REAL with a zero exponent length octet' => ["\x09\x02\x83\x00"];
+    }
+
+    #[Test]
+    #[DataProvider('offContractInputProvider')]
+    public function inputThatUsedToEscapeTheContractIsADecodeException(string $der): void
+    {
+        $this->expectException(DecodeException::class);
+        Element::fromDER($der);
+    }
+
+    #[Test]
+    public function everyUniversalTagStaysWithinTheContract(): void
+    {
+        // A sweep over every universal tag with a short payload: none of them may raise anything but a
+        // DecodeException, whether the tag is implemented or not.
+        $offContract = [];
+        for ($tag = 0; $tag <= 0x1E; ++$tag) {
+            foreach ([chr($tag), chr($tag | 0x20)] as $identifier) {
+                foreach (["\x00", "\x01\x41", "\x02\x41\x42"] as $payload) {
+                    try {
+                        Element::fromDER($identifier . $payload);
+                    } catch (DecodeException) {
+                        // expected
+                    } catch (Throwable $e) {
+                        $offContract[sprintf('%02x %s', $tag, $e::class)] = $e->getMessage();
+                    }
+                }
+            }
+        }
+
+        static::assertSame([], $offContract, 'Off-contract exceptions: ' . json_encode($offContract));
+    }
+
+    #[Test]
+    public function anExtensionFieldBeyondIntRangeIsReported(): void
+    {
+        // TBSCertificate guards the version field with exactly this reasoning; the same intNumber() call was
+        // unguarded on the extension fields, so a 1 KB certificate was enough.
+        $ext = Sequence::create(
+            ObjectIdentifier::create(Extension::OID_BASIC_CONSTRAINTS),
+            OctetString::create(
+                Sequence::create(Boolean::create(true), Integer::create('99999999999999999999999999'))->toDER()
+            )
+        );
+
+        $this->expectException(DecodeException::class);
+        $this->expectExceptionMessage('is too large');
+        Extension::fromASN1($ext)->pathLen();
+    }
+
+    #[Test]
+    public function aTruncatedExtensionIsReported(): void
+    {
+        // Extension::fromASN1() called Structure::at() with no arity check, so a one element SEQUENCE raised an
+        // OutOfBoundsException.
+        $this->expectException(DecodeException::class);
+        $this->expectExceptionMessage('must have 2 or 3 elements');
+        Extension::fromASN1(Sequence::create(ObjectIdentifier::create(Extension::OID_BASIC_CONSTRAINTS)));
+    }
+
+    #[Test]
+    public function aShippedRequestWithAnEmptyAttributeValueSetParses(): void
+    {
+        // The project's own asset, which OpenSSL parses without complaint, reached
+        // Attribute::fromAttributeValues() and raised a LogicException.
+        $csr = CertificationRequest::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/acme-ecdsa.csr'));
+
+        static::assertTrue($csr->verify());
     }
 
     /**

--- a/tests/ASN1/Regression/DerMinimalityTest.php
+++ b/tests/ASN1/Regression/DerMinimalityTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\ASN1\Regression;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\ASN1\Element;
+use SpomkyLabs\Pki\ASN1\Exception\DecodeException;
+use SpomkyLabs\Pki\CryptoEncoding\PEM;
+use SpomkyLabs\Pki\X509\Certificate\Certificate;
+
+/**
+ * A parsed certificate must re-encode to the bytes it arrived as.
+ *
+ * The decoder used to accept a range of non-minimal encodings, so many distinct byte strings decoded to one
+ * object. The outer certificate SEQUENCE header, the signatureAlgorithm and the signatureValue are not covered by
+ * the signature, so one legitimately issued certificate yielded an unbounded family of byte-distinct encodings
+ * that all parsed to it. A caller that hashes what arrived — which is what browsers, OpenSSL and Certificate
+ * Transparency logs do — would see a different certificate each time.
+ *
+ * @internal
+ */
+final class DerMinimalityTest extends TestCase
+{
+    /**
+     * @return Iterator<string, array{string}>
+     */
+    public static function nonMinimalEncodingProvider(): Iterator
+    {
+        // X.690 sect. 10.1: the length uses the minimum number of octets
+        yield 'long form length with a leading zero octet' => ["\x02\x82\x00\x01\x01"];
+        yield 'long form length for a value the short form fits' => ["\x02\x81\x01\x01"];
+        yield 'long form length, four octets, value 1' => ["\x02\x84\x00\x00\x00\x01\x01"];
+
+        // X.690 sect. 8.1.2.3 and 8.1.2.4.2 c: the tag number uses the short form below 31, and no leading zeroes
+        yield 'long form tag number below 31' => ["\x1f\x02\x01\x01"];
+        yield 'long form tag number with a leading 0x80 octet' => ["\x3f\x80\x22\x00"];
+
+        // X.690 sect. 8.3.2: an integer uses the minimum number of octets
+        yield 'integer padded with a leading 0x00' => ["\x02\x02\x00\x01"];
+        yield 'negative integer padded with a leading 0xff' => ["\x02\x02\xff\x80"];
+        yield 'enumerated padded with a leading 0x00' => ["\x0a\x02\x00\x01"];
+
+        // X.690 sect. 8.19: an object identifier has at least one sub-identifier, each minimally encoded
+        yield 'object identifier with a padded sub-identifier' => ["\x06\x04\x55\x1d\x80\x13"];
+        yield 'empty object identifier' => ["\x06\x00"];
+        yield 'empty relative object identifier' => ["\x0d\x00"];
+
+        // X.690 sect. 8: a type whose contents are a single value is primitive
+        yield 'constructed integer' => ["\x22\x01\x01"];
+        yield 'constructed boolean' => ["\x21\x01\xff"];
+        yield 'constructed object identifier' => ["\x26\x03\x55\x1d\x13"];
+        yield 'constructed enumerated' => ["\x2a\x01\x01"];
+
+        // there is no last octet to hold the unused bits, and numBits() came back negative
+        yield 'empty bit string with unused bits' => ["\x03\x01\x07"];
+    }
+
+    #[Test]
+    #[DataProvider('nonMinimalEncodingProvider')]
+    public function aNonMinimalEncodingIsRejected(string $der): void
+    {
+        $this->expectException(DecodeException::class);
+        Element::fromDER($der);
+    }
+
+    /**
+     * @return Iterator<string, array{string}>
+     */
+    public static function minimalEncodingProvider(): Iterator
+    {
+        yield 'integer 1' => ["\x02\x01\x01"];
+        yield 'integer -128' => ["\x02\x01\x80"];
+        yield 'integer 0' => ["\x02\x01\x00"];
+        yield 'integer 128, which needs the leading zero' => ["\x02\x02\x00\x80"];
+        yield 'integer -129, which needs the leading 0xff' => ["\x02\x02\xff\x7f"];
+        yield 'basicConstraints object identifier' => ["\x06\x03\x55\x1d\x13"];
+        yield 'empty bit string' => ["\x03\x01\x00"];
+        yield 'bit string with unused bits' => ["\x03\x02\x07\x80"];
+        yield 'long form length that the short form cannot hold' => ["\x04\x81\x80" . str_repeat("\x00", 128)];
+    }
+
+    #[Test]
+    #[DataProvider('minimalEncodingProvider')]
+    public function aMinimalEncodingStillDecodes(string $der): void
+    {
+        static::assertSame($der, Element::fromDER($der)->toDER());
+    }
+
+    #[Test]
+    public function aShippedCertificateRoundTripsToTheBytesItArrivedAs(): void
+    {
+        $der = PEM::fromFile(TEST_ASSETS_DIR . '/certs/acme-ecdsa.pem')->data();
+
+        static::assertSame($der, Certificate::fromDER($der)->toDER());
+    }
+}

--- a/tests/ASN1/Type/Primitive/Integer/IntegerTest.php
+++ b/tests/ASN1/Type/Primitive/Integer/IntegerTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\Test\ASN1\Type\Primitive\Integer;
 
 use Brick\Math\BigInteger;
-use Brick\Math\Exception\IntegerOverflowException;
 use const PHP_INT_MAX;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SpomkyLabs\Pki\ASN1\Element;
+use SpomkyLabs\Pki\ASN1\Exception\DecodeException;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\NullType;
 use SpomkyLabs\Pki\ASN1\Type\UnspecifiedType;
@@ -56,7 +56,8 @@ final class IntegerTest extends TestCase
     {
         $num = BigInteger::of(PHP_INT_MAX)->plus(1);
         $int = Integer::create($num);
-        $this->expectException(IntegerOverflowException::class);
+        $this->expectException(DecodeException::class);
+        $this->expectExceptionMessage('is too large');
         $int->intNumber();
     }
 }

--- a/tests/ASN1/Type/Primitive/Oid/DecodeTest.php
+++ b/tests/ASN1/Type/Primitive/Oid/DecodeTest.php
@@ -15,10 +15,12 @@ use SpomkyLabs\Pki\ASN1\Type\Primitive\ObjectIdentifier;
 final class DecodeTest extends TestCase
 {
     #[Test]
-    public function type()
+    public function emptyContentOctetsAreRejected()
     {
-        $el = ObjectIdentifier::fromDER("\x6\0");
-        static::assertInstanceOf(ObjectIdentifier::class, $el);
+        // X.690 sect. 8.19.1: an object identifier has at least one sub-identifier
+        $this->expectException(DecodeException::class);
+        $this->expectExceptionMessage('Object identifier must have at least one content octet.');
+        ObjectIdentifier::fromDER("\x6\0");
     }
 
     #[Test]

--- a/tests/X501/Regression/RdnMultisetEqualityTest.php
+++ b/tests/X501/Regression/RdnMultisetEqualityTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\X501\Regression;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\X501\ASN1\AttributeValue\CommonNameValue;
+use SpomkyLabs\Pki\X501\ASN1\RDN;
+
+/**
+ * An RDN is a SET, so two of them are equal when their attributes match as a multiset.
+ *
+ * Both sides used to be DER-sorted and then compared position by position under a case-insensitive rule, so a
+ * case difference alone reordered the sort and two equal RDNs were reported as different.
+ *
+ * @internal
+ */
+final class RdnMultisetEqualityTest extends TestCase
+{
+    #[Test]
+    public function aCaseDifferenceDoesNotReorderTheComparison(): void
+    {
+        // RFC 5280 sect. 7.1 makes these two equal.
+        $a = RDN::fromAttributeValues(CommonNameValue::create('a'), CommonNameValue::create('B'));
+        $b = RDN::fromAttributeValues(CommonNameValue::create('A'), CommonNameValue::create('b'));
+
+        static::assertTrue($a->equals($b));
+        static::assertTrue($b->equals($a));
+    }
+
+    #[Test]
+    public function theOrderOfTheAttributesDoesNotMatter(): void
+    {
+        $a = RDN::fromAttributeValues(CommonNameValue::create('a'), CommonNameValue::create('b'));
+        $b = RDN::fromAttributeValues(CommonNameValue::create('B'), CommonNameValue::create('A'));
+
+        static::assertTrue($a->equals($b));
+        static::assertTrue($b->equals($a));
+    }
+
+    #[Test]
+    public function differentAttributesAreStillDifferent(): void
+    {
+        $a = RDN::fromAttributeValues(CommonNameValue::create('a'), CommonNameValue::create('b'));
+        $b = RDN::fromAttributeValues(CommonNameValue::create('a'), CommonNameValue::create('c'));
+
+        static::assertFalse($a->equals($b));
+        static::assertFalse($b->equals($a));
+    }
+
+    #[Test]
+    public function aRepeatedValueIsNotMatchedTwice(): void
+    {
+        $a = RDN::fromAttributeValues(CommonNameValue::create('a'), CommonNameValue::create('a'));
+        $b = RDN::fromAttributeValues(CommonNameValue::create('a'), CommonNameValue::create('b'));
+
+        static::assertFalse($a->equals($b));
+        static::assertFalse($b->equals($a));
+    }
+}

--- a/tests/X509/Integration/AcValidation/NoTargetingTest.php
+++ b/tests/X509/Integration/AcValidation/NoTargetingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\Test\X509\Integration\AcValidation;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
@@ -67,7 +68,7 @@ final class NoTargetingTest extends TestCase
     public function validate()
     {
         $config = ACValidationConfig::create(self::$_holderPath, self::$_issuerPath)
-            ->withEvaluationTime(new DateTimeImmutable('2025-01-01'));
+            ->withEvaluationTime(new DateTimeImmutable('2025-01-01', new DateTimeZone('UTC')));
         $config = $config->withTargets(TargetName::create(DNSName::create('test')));
         $validator = ACValidator::create(self::$_ac, $config);
         static::assertInstanceOf(AttributeCertificate::class, $validator->validate());

--- a/tests/X509/Integration/AcValidation/PassingTest.php
+++ b/tests/X509/Integration/AcValidation/PassingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\Test\X509\Integration\AcValidation;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
@@ -71,7 +72,7 @@ final class PassingTest extends TestCase
     public function validate(): void
     {
         $config = ACValidationConfig::create(self::$_holderPath, self::$_issuerPath)
-            ->withEvaluationTime(new DateTimeImmutable('2025-01-01'));
+            ->withEvaluationTime(new DateTimeImmutable('2025-01-01', new DateTimeZone('UTC')));
         $config = $config->withTargets(TargetName::create(DNSName::create('test')));
         $validator = ACValidator::create(self::$_ac, $config);
         static::assertInstanceOf(AttributeCertificate::class, $validator->validate());

--- a/tests/X509/Integration/Workflow/RequestToCertTest.php
+++ b/tests/X509/Integration/Workflow/RequestToCertTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\Test\X509\Integration\Workflow;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -114,7 +115,7 @@ final class RequestToCertTest extends TestCase
     #[Depends('buildPath')]
     public function validatePath(CertificationPath $path)
     {
-        $config = PathValidationConfig::defaultConfig()->withDateTime(new DateTimeImmutable('2016-05-02 12:30:00'));
+        $config = PathValidationConfig::defaultConfig()->withDateTime(new DateTimeImmutable('2016-05-02 12:30:00', new DateTimeZone('UTC')));
         $result = $path->validate($config);
         static::assertInstanceOf(PathValidationResult::class, $result);
     }

--- a/tests/X509/Regression/AttributeCertificateValidationTest.php
+++ b/tests/X509/Regression/AttributeCertificateValidationTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\X509\Regression;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\CryptoEncoding\PEM;
+use SpomkyLabs\Pki\CryptoEncoding\PEMBundle;
+use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\Signature\ECDSAWithSHA256AlgorithmIdentifier;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKeyInfo;
+use SpomkyLabs\Pki\X509\AttributeCertificate\AttCertIssuer;
+use SpomkyLabs\Pki\X509\AttributeCertificate\AttCertValidityPeriod;
+use SpomkyLabs\Pki\X509\AttributeCertificate\AttributeCertificate;
+use SpomkyLabs\Pki\X509\AttributeCertificate\AttributeCertificateInfo;
+use SpomkyLabs\Pki\X509\AttributeCertificate\Attributes;
+use SpomkyLabs\Pki\X509\AttributeCertificate\Holder;
+use SpomkyLabs\Pki\X509\AttributeCertificate\Validation\ACValidationConfig;
+use SpomkyLabs\Pki\X509\AttributeCertificate\Validation\ACValidator;
+use SpomkyLabs\Pki\X509\AttributeCertificate\Validation\Exception\ACValidationException;
+use SpomkyLabs\Pki\X509\Certificate\Certificate;
+use SpomkyLabs\Pki\X509\Certificate\CertificateBundle;
+use SpomkyLabs\Pki\X509\CertificationPath\CertificationPath;
+use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationConfig;
+
+/**
+ * Three hardening items in the attribute certificate validator.
+ *
+ * The evaluation clock was snapshotted at construction, so a config object shared by a DI container or held
+ * across requests in a worker runtime kept validating expired credentials for the lifetime of the process. RFC
+ * 5755 section 5 check 4 was neither implemented nor documented as the caller's job. And the caller's maximum
+ * path length was overridden for both paths.
+ *
+ * @internal
+ */
+final class AttributeCertificateValidationTest extends TestCase
+{
+    private static ?CertificationPath $holderPath = null;
+
+    private static ?CertificationPath $issuerPath = null;
+
+    private static ?Certificate $issuer = null;
+
+    private static ?Certificate $holder = null;
+
+    private static ?AttributeCertificate $ac = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        $rootCa = Certificate::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/acme-ca.pem'));
+        $interms = CertificateBundle::fromPEMBundle(
+            PEMBundle::fromFile(TEST_ASSETS_DIR . '/certs/intermediate-bundle.pem')
+        );
+        self::$holder = Certificate::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/acme-rsa.pem'));
+        self::$issuer = Certificate::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/acme-ecdsa.pem'));
+        $issuerKey = PrivateKeyInfo::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/keys/acme-ec.pem'));
+
+        self::$holderPath = CertificationPath::fromTrustAnchorToTarget($rootCa, self::$holder, $interms);
+        self::$issuerPath = CertificationPath::fromTrustAnchorToTarget($rootCa, self::$issuer, $interms);
+
+        self::$ac = AttributeCertificateInfo::create(
+            Holder::fromPKC(self::$holder),
+            AttCertIssuer::fromPKC(self::$issuer),
+            AttCertValidityPeriod::fromStrings('2025-01-01', '2025-01-01 + 1 hour'),
+            Attributes::create()
+        )->sign(ECDSAWithSHA256AlgorithmIdentifier::create(), $issuerKey);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$holderPath = null;
+        self::$issuerPath = null;
+        self::$issuer = null;
+        self::$holder = null;
+        self::$ac = null;
+    }
+
+    #[Test]
+    public function theEvaluationClockIsNotSnapshottedAtConstruction(): void
+    {
+        $config = ACValidationConfig::create(self::$holderPath, self::$issuerPath);
+
+        $first = $config->evaluationTime();
+        usleep(1100);
+        $second = $config->evaluationTime();
+
+        static::assertGreaterThan($first, $second, 'the clock must be read on every evaluation');
+    }
+
+    #[Test]
+    public function anExplicitEvaluationTimeIsStillPinned(): void
+    {
+        $pinned = new DateTimeImmutable('2025-01-01', new DateTimeZone('UTC'));
+        $config = ACValidationConfig::create(self::$holderPath, self::$issuerPath)->withEvaluationTime($pinned);
+
+        static::assertSame($pinned, $config->evaluationTime());
+        static::assertSame($pinned, $config->evaluationTime());
+    }
+
+    #[Test]
+    public function aTrustedAttributeAuthorityListIsEnforced(): void
+    {
+        $config = self::pinnedConfig()->withTrustedAttributeAuthorities(self::$issuer);
+
+        static::assertInstanceOf(AttributeCertificate::class, ACValidator::create(self::$ac, $config)->validate());
+    }
+
+    #[Test]
+    public function anEndEntityCertificateThatIsNotOnTheListIsRefused(): void
+    {
+        // Without the list the validator accepts whatever end-entity certificate the issuer path ends in, so a
+        // caller who locates the attribute authority by matching the issuer name against a bundle turns every
+        // end-entity certificate under the trust anchor into an attribute authority.
+        $config = self::pinnedConfig()->withTrustedAttributeAuthorities(self::$holder);
+
+        $this->expectException(ACValidationException::class);
+        $this->expectExceptionMessage('not a trusted attribute authority');
+        ACValidator::create(self::$ac, $config)->validate();
+    }
+
+    #[Test]
+    public function withoutAListTheCheckIsSkippedAsBefore(): void
+    {
+        static::assertNull(self::pinnedConfig()->trustedAttributeAuthorities());
+        static::assertInstanceOf(
+            AttributeCertificate::class,
+            ACValidator::create(self::$ac, self::pinnedConfig())->validate()
+        );
+    }
+
+    #[Test]
+    public function theCallersMaximumPathLengthIsHonoured(): void
+    {
+        // withMaxLength(count($path)) used to be applied to both paths, which made this setting a no-op.
+        $config = self::pinnedConfig()->withPathValidationConfig(
+            PathValidationConfig::defaultConfig()->withMaxLength(0)
+        );
+
+        $this->expectException(ACValidationException::class);
+        $this->expectExceptionMessage("Failed to validate holder PKC's certification path.");
+        ACValidator::create(self::$ac, $config)->validate();
+    }
+
+    #[Test]
+    public function aGenerousLimitStillValidates(): void
+    {
+        $config = self::pinnedConfig()->withPathValidationConfig(
+            PathValidationConfig::defaultConfig()->withMaxLength(5)
+        );
+
+        static::assertInstanceOf(AttributeCertificate::class, ACValidator::create(self::$ac, $config)->validate());
+    }
+
+    private static function pinnedConfig(): ACValidationConfig
+    {
+        return ACValidationConfig::create(self::$holderPath, self::$issuerPath)
+            ->withEvaluationTime(new DateTimeImmutable('2025-01-01', new DateTimeZone('UTC')));
+    }
+}

--- a/tests/X509/Regression/CertificateIdentityTest.php
+++ b/tests/X509/Regression/CertificateIdentityTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\X509\Regression;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\CryptoEncoding\PEM;
+use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\Signature\SHA256WithRSAEncryptionAlgorithmIdentifier;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKeyInfo;
+use SpomkyLabs\Pki\X501\ASN1\Name;
+use SpomkyLabs\Pki\X509\Certificate\Certificate;
+use SpomkyLabs\Pki\X509\Certificate\CertificateBundle;
+use SpomkyLabs\Pki\X509\Certificate\Extension\BasicConstraintsExtension;
+use SpomkyLabs\Pki\X509\Certificate\TBSCertificate;
+use SpomkyLabs\Pki\X509\Certificate\Validity;
+
+/**
+ * Certificate::equals() compared the serial number, the SHA-1 based key identifier of the subjectPublicKeyInfo
+ * and the subject DN, and nothing else.
+ *
+ * Those are three public values an attacker is free to repeat. CertificateBundle::contains() is built on it, and
+ * the API shape invites "is this certificate in my trust store or my pinned set?".
+ *
+ * @internal
+ */
+final class CertificateIdentityTest extends TestCase
+{
+    private static ?PrivateKeyInfo $key = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$key = PrivateKey::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/keys/acme-ca-rsa.pem'))
+            ->privateKeyInfo();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$key = null;
+    }
+
+    #[Test]
+    public function aCertificateAgreeingOnTheThreePublicValuesIsNotTheSameCertificate(): void
+    {
+        [$root, $rogue] = self::twinCertificates();
+
+        static::assertSame($root->tbsCertificate()->serialNumber(), $rogue->tbsCertificate()->serialNumber());
+        static::assertTrue($root->tbsCertificate()->subject()->equals($rogue->tbsCertificate()->subject()));
+        static::assertNotSame($root->toDER(), $rogue->toDER());
+
+        static::assertFalse($root->equals($rogue));
+        static::assertFalse($rogue->equals($root));
+    }
+
+    #[Test]
+    public function aTrustStoreDoesNotContainACertificateThatIsNotInIt(): void
+    {
+        [$root, $rogue] = self::twinCertificates();
+        $trustStore = CertificateBundle::create($root);
+
+        static::assertTrue($trustStore->contains($root));
+        static::assertFalse($trustStore->contains($rogue));
+    }
+
+    #[Test]
+    public function aCertificateStillEqualsItself(): void
+    {
+        [$root] = self::twinCertificates();
+
+        static::assertTrue($root->equals($root));
+        static::assertTrue($root->equals(Certificate::fromDER($root->toDER())));
+    }
+
+    #[Test]
+    public function theLooserPredicateIsAvailableUnderItsOwnName(): void
+    {
+        [$root, $rogue] = self::twinCertificates();
+
+        static::assertTrue($root->hasEqualSubjectIdentity($rogue));
+    }
+
+    /**
+     * A real root and a certificate repeating its serial number, subject DN and key, differing in issuer,
+     * validity and every extension.
+     *
+     * @return array{Certificate, Certificate}
+     */
+    private static function twinCertificates(): array
+    {
+        $subject = Name::fromString('cn=Corp Root CA');
+
+        $root = TBSCertificate::create(
+            $subject,
+            self::$key->publicKeyInfo(),
+            $subject,
+            Validity::fromStrings('now - 1 hour', 'now + 10 years')
+        )
+            ->withSerialNumber('42')
+            ->withAdditionalExtensions(BasicConstraintsExtension::create(true, true))
+            ->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), self::$key);
+
+        $rogue = TBSCertificate::create(
+            $subject,
+            self::$key->publicKeyInfo(),
+            Name::fromString('cn=Somewhere Else'),
+            Validity::fromStrings('now - 1 hour', 'now + 1 hour')
+        )
+            ->withSerialNumber('42')
+            ->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), self::$key);
+
+        return [$root, $rogue];
+    }
+}

--- a/tests/X509/Regression/CsrExtensionCopyTest.php
+++ b/tests/X509/Regression/CsrExtensionCopyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\Pki\Test\X509\Regression;
 
+use const E_USER_DEPRECATED;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -61,7 +62,7 @@ final class CsrExtensionCopyTest extends TestCase
     public function ordinaryExtensionsAreStillCopied(): void
     {
         // Issuers that relied on subjectAltName being carried over keep working unchanged.
-        $tbs = TBSCertificate::fromCSR(self::hostileCsr());
+        $tbs = TBSCertificate::fromCSR(self::hostileCsr(), null);
 
         static::assertTrue($tbs->extensions()->hasSubjectAlternativeName());
         static::assertSame(
@@ -135,6 +136,81 @@ final class CsrExtensionCopyTest extends TestCase
             TBSCertificate::fromCSR($csr)->extensions()
                 ->has($oid)
         );
+    }
+
+    #[Test]
+    public function copyingWithoutNamingTheExtensionsIsAnnounced(): void
+    {
+        // The deny list is the wrong default: the set of extensions that matter grows over time and every future
+        // one would be copied. A request whose subject is cn=Attacker can carry DNS:victim-bank.example.com.
+        $deprecations = self::collectDeprecations(static fn () => TBSCertificate::fromCSR(self::hostileCsr()));
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(Extension::OID_SUBJECT_ALT_NAME, $deprecations[0]);
+    }
+
+    #[Test]
+    public function namingTheExtensionsIsSilent(): void
+    {
+        $deprecations = self::collectDeprecations(
+            static fn () => TBSCertificate::fromCSR(self::hostileCsr(), [Extension::OID_SUBJECT_ALT_NAME])
+        );
+
+        static::assertSame([], $deprecations);
+    }
+
+    #[Test]
+    public function askingForTheOldDefaultOnPurposeIsSilent(): void
+    {
+        $deprecations = self::collectDeprecations(
+            static fn () => TBSCertificate::fromCSR(self::hostileCsr(), null)
+        );
+
+        static::assertSame([], $deprecations);
+    }
+
+    #[Test]
+    public function anUnknownCriticalExtensionIsNeverCopied(): void
+    {
+        // It would be signed verbatim and then no RFC 5280 validator would accept the certificate, this
+        // library's own path validator included: the issuer produces a certificate that is dead on arrival.
+        $oid = '1.2.3.4.5.6.7.8';
+        $csr = self::csrRequesting(UnknownExtension::create($oid, true, NullType::create()));
+
+        $tbs = TBSCertificate::fromCSR($csr, [$oid]);
+
+        static::assertFalse($tbs->extensions()->has($oid));
+    }
+
+    #[Test]
+    public function anUnknownNonCriticalExtensionIsStillCopied(): void
+    {
+        $oid = '1.2.3.4.5.6.7.8';
+        $csr = self::csrRequesting(UnknownExtension::create($oid, false, NullType::create()));
+
+        $tbs = TBSCertificate::fromCSR($csr, [$oid]);
+
+        static::assertTrue($tbs->extensions()->has($oid));
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function collectDeprecations(callable $fn): array
+    {
+        $collected = [];
+        set_error_handler(static function (int $errno, string $message) use (&$collected): bool {
+            $collected[] = $message;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $fn();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $collected;
     }
 
     private static function csrRequesting(Extension ...$extensions): CertificationRequest

--- a/tests/X509/Regression/EdDSASignatureTest.php
+++ b/tests/X509/Regression/EdDSASignatureTest.php
@@ -8,8 +8,11 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\CryptoBridge\Crypto\OpenSSLCrypto;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
 use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
+use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\Asymmetric\Ed25519AlgorithmIdentifier;
+use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\Asymmetric\Ed448AlgorithmIdentifier;
 use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\Signature\SHA256WithRSAEncryptionAlgorithmIdentifier;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKey;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKeyInfo;
@@ -82,6 +85,35 @@ final class EdDSASignatureTest extends TestCase
     }
 
     #[Test]
+    public function ed25519IsSupportedOnEverySupportedRuntime(): void
+    {
+        // The OpenSSL extension only grew EdDSA in PHP 8.5; ext-sodium, bundled since PHP 7.2, covers Ed25519 on
+        // everything older.
+        static::assertTrue(
+            (new OpenSSLCrypto())->supportsSignatureAlgorithm(Ed25519AlgorithmIdentifier::create())
+        );
+    }
+
+    #[Test]
+    public function anUnsupportedEdDSAAlgorithmFailsClosedRatherThanThrowing(): void
+    {
+        // Ed448 has no fallback outside the OpenSSL extension. Where the runtime cannot check the signature, the
+        // bool returning API must say "not verified" rather than take the process down.
+        if ((new OpenSSLCrypto())->supportsSignatureAlgorithm(Ed448AlgorithmIdentifier::create())) {
+            static::markTestSkipped('This runtime verifies Ed448.');
+        }
+
+        $cert = self::selfSignedCertificate('ed448');
+
+        static::assertFalse(
+            $cert->verify(
+                $cert->tbsCertificate()
+                    ->subjectPublicKeyInfo()
+            )
+        );
+    }
+
+    #[Test]
     public function verifyReturnsFalseRatherThanThrowingOnAnAlgorithmTheEngineCannotHandle(): void
     {
         // The algorithm is named by the certificate, so an attacker picks it. A bool returning predicate must
@@ -145,6 +177,13 @@ final class EdDSASignatureTest extends TestCase
      */
     private static function selfSignedCertificate(string $algorithm): Certificate
     {
+        $identifier = $algorithm === 'ed25519'
+            ? Ed25519AlgorithmIdentifier::create()
+            : Ed448AlgorithmIdentifier::create();
+        if (! (new OpenSSLCrypto())->supportsSignatureAlgorithm($identifier)) {
+            static::markTestSkipped(sprintf('This runtime cannot verify %s.', $identifier->name()));
+        }
+
         $dir = sys_get_temp_dir() . '/pki-eddsa-' . bin2hex(random_bytes(8));
         mkdir($dir);
 

--- a/tests/X509/Regression/EdDSASignatureTest.php
+++ b/tests/X509/Regression/EdDSASignatureTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\X509\Regression;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\CryptoEncoding\PEM;
+use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
+use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\Signature\SHA256WithRSAEncryptionAlgorithmIdentifier;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKeyInfo;
+use SpomkyLabs\Pki\X501\ASN1\Name;
+use SpomkyLabs\Pki\X509\Certificate\Certificate;
+use SpomkyLabs\Pki\X509\Certificate\TBSCertificate;
+use SpomkyLabs\Pki\X509\Certificate\Validity;
+use SpomkyLabs\Pki\X509\CertificationPath\CertificationPath;
+use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationConfig;
+use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationResult;
+use function sprintf;
+
+/**
+ * Ed25519 and Ed448 were in the default allowed signature algorithms but could not be verified.
+ *
+ * OpenSSLCrypto::MAP_DIGEST_OID had an entry for neither, so a chain OpenSSL validates could not be validated at
+ * all while the configuration advertised the capability. EdDSA is a one shot scheme: the message is not
+ * pre-hashed, and openssl_verify() takes 0 as the digest method.
+ *
+ * @internal
+ */
+final class EdDSASignatureTest extends TestCase
+{
+    /**
+     * @return Iterator<string, array{string}>
+     */
+    public static function edDSAAlgorithmProvider(): Iterator
+    {
+        yield 'Ed25519' => ['ed25519'];
+        yield 'Ed448' => ['ed448'];
+    }
+
+    #[Test]
+    #[DataProvider('edDSAAlgorithmProvider')]
+    public function anEdDSACertificateVerifies(string $algorithm): void
+    {
+        $cert = self::selfSignedCertificate($algorithm);
+        $key = $cert->tbsCertificate()
+            ->subjectPublicKeyInfo();
+
+        static::assertTrue($cert->verify($key));
+    }
+
+    #[Test]
+    #[DataProvider('edDSAAlgorithmProvider')]
+    public function anEdDSAChainValidates(string $algorithm): void
+    {
+        $cert = self::selfSignedCertificate($algorithm);
+
+        static::assertInstanceOf(
+            PathValidationResult::class,
+            CertificationPath::create($cert)
+                ->validate(PathValidationConfig::defaultConfig()->withTrustAnchor($cert))
+        );
+    }
+
+    #[Test]
+    #[DataProvider('edDSAAlgorithmProvider')]
+    public function aTamperedEdDSACertificateDoesNotVerify(string $algorithm): void
+    {
+        $cert = self::selfSignedCertificate($algorithm);
+        $other = self::selfSignedCertificate($algorithm);
+
+        static::assertFalse(
+            $cert->verify(
+                $other->tbsCertificate()
+                    ->subjectPublicKeyInfo()
+            )
+        );
+    }
+
+    #[Test]
+    public function verifyReturnsFalseRatherThanThrowingOnAnAlgorithmTheEngineCannotHandle(): void
+    {
+        // The algorithm is named by the certificate, so an attacker picks it. A bool returning predicate must
+        // not turn `if (! $cert->verify($key))` into an unhandled fatal.
+        $key = PrivateKey::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/keys/acme-ca-rsa.pem'))
+            ->privateKeyInfo();
+        $cert = self::rsaCertificate($key);
+
+        static::assertFalse(
+            $cert->verify(
+                PrivateKey::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/keys/acme-ec.pem'))
+                    ->privateKeyInfo()
+                    ->publicKeyInfo()
+            )
+        );
+    }
+
+    #[Test]
+    public function rsassaPssIsNoLongerAdvertisedWhileItIsNotImplemented(): void
+    {
+        // A PSS signed certificate is refused when it is parsed, so the entry was dead configuration.
+        static::assertNotContains(
+            AlgorithmIdentifier::OID_RSASSA_PSS_ENCRYPTION,
+            PathValidationConfig::DEFAULT_ALLOWED_SIGNATURE_ALGORITHMS
+        );
+        static::assertNotContains(
+            AlgorithmIdentifier::OID_RSASSA_PSS_ENCRYPTION,
+            PathValidationConfig::HARDENED_ALLOWED_SIGNATURE_ALGORITHMS
+        );
+    }
+
+    #[Test]
+    public function edDSAIsStillInTheDefaultSet(): void
+    {
+        static::assertContains(
+            AlgorithmIdentifier::OID_ED25519,
+            PathValidationConfig::DEFAULT_ALLOWED_SIGNATURE_ALGORITHMS
+        );
+        static::assertContains(
+            AlgorithmIdentifier::OID_ED448,
+            PathValidationConfig::DEFAULT_ALLOWED_SIGNATURE_ALGORITHMS
+        );
+    }
+
+    private static function rsaCertificate(PrivateKeyInfo $key): Certificate
+    {
+        $subject = Name::fromString('cn=Test Root');
+
+        return TBSCertificate::create(
+            $subject,
+            $key->publicKeyInfo(),
+            $subject,
+            Validity::fromStrings('now - 1 hour', 'now + 1 hour')
+        )
+            ->withSerialNumber('1')
+            ->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), $key);
+    }
+
+    /**
+     * OpenSSL is the only EdDSA implementation available here, so the fixture is generated rather than shipped.
+     */
+    private static function selfSignedCertificate(string $algorithm): Certificate
+    {
+        $dir = sys_get_temp_dir() . '/pki-eddsa-' . bin2hex(random_bytes(8));
+        mkdir($dir);
+
+        try {
+            exec(sprintf(
+                'openssl genpkey -algorithm %s -out %s/key.pem 2>/dev/null',
+                escapeshellarg($algorithm),
+                escapeshellarg($dir)
+            ));
+            exec(sprintf(
+                'openssl req -new -x509 -key %s/key.pem -subj /CN=eddsa -days 3650 -out %s/cert.pem 2>/dev/null',
+                escapeshellarg($dir),
+                escapeshellarg($dir)
+            ));
+
+            if (! file_exists($dir . '/cert.pem')) {
+                static::markTestSkipped(sprintf('The available OpenSSL cannot generate an %s key.', $algorithm));
+            }
+
+            return Certificate::fromPEM(PEM::fromFile($dir . '/cert.pem'));
+        } finally {
+            array_map(unlink(...), glob($dir . '/*') ?: []);
+            rmdir($dir);
+        }
+    }
+}

--- a/tests/X509/Regression/PathBuildingResolutionTest.php
+++ b/tests/X509/Regression/PathBuildingResolutionTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\X509\Regression;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\CryptoEncoding\PEM;
+use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\Signature\SHA256WithRSAEncryptionAlgorithmIdentifier;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKeyInfo;
+use SpomkyLabs\Pki\X501\ASN1\Name;
+use SpomkyLabs\Pki\X509\Certificate\Certificate;
+use SpomkyLabs\Pki\X509\Certificate\CertificateBundle;
+use SpomkyLabs\Pki\X509\Certificate\Extension\BasicConstraintsExtension;
+use SpomkyLabs\Pki\X509\Certificate\Extension\SubjectKeyIdentifierExtension;
+use SpomkyLabs\Pki\X509\Certificate\TBSCertificate;
+use SpomkyLabs\Pki\X509\Certificate\Validity;
+use SpomkyLabs\Pki\X509\CertificationPath\CertificationPath;
+use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationConfig;
+use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationResult;
+
+/**
+ * Two limitations in CertificationPathBuilder::findIssuers().
+ *
+ * A certificate without an authorityKeyIdentifier could never be chained, which pushed integrators towards
+ * CertificationPath::create(), the unsafe constructor. And the lookup index was keyed on the subjectKeyIdentifier
+ * a certificate claims for itself, which is arbitrary data never checked against the key: one extra certificate
+ * in a peer-supplied bundle was enough to deny validation of a perfectly good chain.
+ *
+ * @internal
+ */
+final class PathBuildingResolutionTest extends TestCase
+{
+    private static ?PrivateKeyInfo $caKey = null;
+
+    private static ?PrivateKeyInfo $leafKey = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$caKey = PrivateKey::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/keys/acme-ca-rsa.pem'))
+            ->privateKeyInfo();
+        self::$leafKey = PrivateKey::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/keys/acme-rsa.pem'))
+            ->privateKeyInfo();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$caKey = null;
+        self::$leafKey = null;
+    }
+
+    #[Test]
+    public function aCertificateWithoutAnAuthorityKeyIdentifierIsChained(): void
+    {
+        $root = self::root();
+        $leaf = self::leaf($root, false);
+
+        static::assertFalse($leaf->tbsCertificate()->extensions()->hasAuthorityKeyIdentifier());
+
+        $path = CertificationPath::toTarget($leaf, CertificateBundle::create($root));
+
+        static::assertCount(2, $path);
+        static::assertInstanceOf(
+            PathValidationResult::class,
+            $path->validate(PathValidationConfig::defaultConfig()->withTrustAnchor($root))
+        );
+    }
+
+    #[Test]
+    public function aCertificateWithAnAuthorityKeyIdentifierIsStillChained(): void
+    {
+        $root = self::root();
+        $leaf = self::leaf($root, true);
+
+        $path = CertificationPath::toTarget($leaf, CertificateBundle::create($root));
+
+        static::assertCount(2, $path);
+        static::assertTrue($path->startsWith($root));
+    }
+
+    #[Test]
+    public function aClaimedSubjectKeyIdentifierDoesNotDisplaceTheRealIssuer(): void
+    {
+        // The rogue certificate repeats the root's subject DN and its subjectKeyIdentifier, but holds another
+        // key. It used to take the root's place in the lookup index, so the builder returned the rogue path and
+        // validation failed on the signature.
+        $root = self::root();
+        $leaf = self::leaf($root, true);
+        $rogue = self::rogueTwinOf($root);
+
+        $path = CertificationPath::toTarget($leaf, CertificateBundle::create($rogue, $root));
+
+        static::assertTrue($path->startsWith($root));
+        static::assertInstanceOf(
+            PathValidationResult::class,
+            $path->validate(PathValidationConfig::defaultConfig()->withTrustAnchor($root))
+        );
+    }
+
+    #[Test]
+    public function theRealIssuerIsAmongTheCandidatesWhateverTheBundleOrder(): void
+    {
+        $root = self::root();
+        $leaf = self::leaf($root, true);
+        $rogue = self::rogueTwinOf($root);
+
+        foreach ([[$rogue, $root], [$root, $rogue]] as $certs) {
+            $found = CertificateBundle::create(...$certs)->allBySubjectKeyIdentifier(
+                $root->tbsCertificate()
+                    ->extensions()
+                    ->subjectKeyIdentifier()
+                    ->keyIdentifier()
+            );
+
+            static::assertCount(2, $found, 'both candidates must be offered, not one of them silently dropped');
+        }
+
+        static::assertTrue(
+            CertificationPath::toTarget($leaf, CertificateBundle::create($rogue, $root))->startsWith($root)
+        );
+    }
+
+    private static function root(): Certificate
+    {
+        $subject = Name::fromString('cn=Corp Root CA');
+
+        return TBSCertificate::create(
+            $subject,
+            self::$caKey->publicKeyInfo(),
+            $subject,
+            Validity::fromStrings('now - 1 hour', 'now + 10 years')
+        )
+            ->withSerialNumber('1')
+            ->withAdditionalExtensions(
+                BasicConstraintsExtension::create(true, true),
+                SubjectKeyIdentifierExtension::create(false, self::$caKey->publicKeyInfo()->keyIdentifier())
+            )
+            ->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), self::$caKey);
+    }
+
+    /**
+     * A certificate that repeats the root's subject DN and its declared key identifier, but holds another key.
+     */
+    private static function rogueTwinOf(Certificate $root): Certificate
+    {
+        $subject = $root->tbsCertificate()
+            ->subject();
+
+        return TBSCertificate::create(
+            $subject,
+            self::$leafKey->publicKeyInfo(),
+            $subject,
+            Validity::fromStrings('now - 1 hour', 'now + 10 years')
+        )
+            ->withSerialNumber('99')
+            ->withAdditionalExtensions(
+                BasicConstraintsExtension::create(true, true),
+                SubjectKeyIdentifierExtension::create(
+                    false,
+                    $root->tbsCertificate()
+                        ->extensions()
+                        ->subjectKeyIdentifier()
+                        ->keyIdentifier()
+                )
+            )
+            ->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), self::$leafKey);
+    }
+
+    private static function leaf(Certificate $root, bool $withAuthorityKeyIdentifier): Certificate
+    {
+        $tbs = TBSCertificate::create(
+            Name::fromString('cn=leaf'),
+            self::$leafKey->publicKeyInfo(),
+            $root->tbsCertificate()
+                ->subject(),
+            Validity::fromStrings('now - 1 hour', 'now + 1 hour')
+        )->withSerialNumber('2');
+
+        if ($withAuthorityKeyIdentifier) {
+            $tbs = $tbs->withIssuerCertificate($root);
+        }
+
+        return $tbs->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), self::$caKey);
+    }
+}

--- a/tests/X509/Regression/SignedStructureMalleabilityTest.php
+++ b/tests/X509/Regression/SignedStructureMalleabilityTest.php
@@ -60,7 +60,7 @@ final class SignedStructureMalleabilityTest extends TestCase
     }
 
     #[Test]
-    public function aNonMinimalSerialNumberNoLongerVerifies(): void
+    public function aNonMinimalSerialNumberIsRejected(): void
     {
         $der = self::leafDER();
         $issuerKey = self::issuerPublicKey();
@@ -70,31 +70,26 @@ final class SignedStructureMalleabilityTest extends TestCase
         $mutated = self::withPaddedInteger($der, 1);
         static::assertNotSame($der, $mutated);
 
-        $cert = Certificate::fromDER($mutated);
-        // The mutated encoding still parses to the very same certificate ...
-        static::assertSame(
-            Certificate::fromDER($der)->tbsCertificate()
-                ->serialNumber(),
-            $cert->tbsCertificate()
-                ->serialNumber()
-        );
-        // ... but it is no longer the byte string the issuer signed.
-        static::assertFalse($cert->verify($issuerKey));
+        // X.690 sect. 8.3.2 requires the minimum number of octets, so the mutated encoding never parses and the
+        // certificate has a single valid encoding rather than a family of them.
+        $this->expectException(DecodeException::class);
+        $this->expectExceptionMessage('minimum number of octets');
+        Certificate::fromDER($mutated);
     }
 
     #[Test]
-    public function aNonMinimalCertificationRequestVersionNoLongerVerifies(): void
+    public function aNonMinimalCertificationRequestVersionIsRejected(): void
     {
         $der = self::csrDER();
         static::assertTrue(CertificationRequest::fromDER($der)->verify(), 'The untouched request must verify.');
 
-        $csr = CertificationRequest::fromDER(self::withPaddedInteger($der, 0));
-        static::assertSame(0, $csr->certificationRequestInfo()->version());
-        static::assertFalse($csr->verify());
+        $this->expectException(DecodeException::class);
+        $this->expectExceptionMessage('minimum number of octets');
+        CertificationRequest::fromDER(self::withPaddedInteger($der, 0));
     }
 
     #[Test]
-    public function aNonMinimalAttributeCertificateVersionNoLongerVerifies(): void
+    public function aNonMinimalAttributeCertificateVersionIsRejected(): void
     {
         $der = self::acDER();
         $issuerKey = self::acIssuerPublicKey();
@@ -103,9 +98,9 @@ final class SignedStructureMalleabilityTest extends TestCase
             'The untouched attribute certificate must verify.'
         );
 
-        $ac = AttributeCertificate::fromDER(self::withPaddedInteger($der, 0));
-        static::assertSame(1, $ac->acinfo()->version());
-        static::assertFalse($ac->verify($issuerKey));
+        $this->expectException(DecodeException::class);
+        $this->expectExceptionMessage('minimum number of octets');
+        AttributeCertificate::fromDER(self::withPaddedInteger($der, 0));
     }
 
     #[Test]

--- a/tests/X509/Regression/TrustAnchorFallbackTest.php
+++ b/tests/X509/Regression/TrustAnchorFallbackTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\X509\Regression;
+
+use const E_USER_DEPRECATED;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\CryptoEncoding\PEM;
+use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\Signature\SHA256WithRSAEncryptionAlgorithmIdentifier;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKeyInfo;
+use SpomkyLabs\Pki\X501\ASN1\Name;
+use SpomkyLabs\Pki\X509\Certificate\Certificate;
+use SpomkyLabs\Pki\X509\Certificate\CertificateBundle;
+use SpomkyLabs\Pki\X509\Certificate\Extension\BasicConstraintsExtension;
+use SpomkyLabs\Pki\X509\Certificate\TBSCertificate;
+use SpomkyLabs\Pki\X509\Certificate\Validity;
+use SpomkyLabs\Pki\X509\CertificationPath\CertificationPath;
+use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationConfig;
+
+/**
+ * validate() refuses to run without an explicit trust anchor only when the path came from fromCertificateChain().
+ *
+ * The guard was attached to the constructor that was used rather than to the invariant it protects, so a path
+ * built with create() on peer material still fell back to using that material's own first certificate as the
+ * anchor. Nothing in the result told a chain anchored in the caller's trust store from one anchored in the
+ * attacker's. The fallback is now announced, so an application can find the call sites before it is removed.
+ *
+ * @internal
+ */
+final class TrustAnchorFallbackTest extends TestCase
+{
+    private static ?PrivateKeyInfo $key = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$key = PrivateKey::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/keys/acme-ca-rsa.pem'))
+            ->privateKeyInfo();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$key = null;
+    }
+
+    #[Test]
+    public function createFallingBackToItsOwnHeadIsAnnounced(): void
+    {
+        [$root, $leaf] = self::path();
+
+        $deprecations = self::collectDeprecations(
+            static fn () => CertificationPath::create($root, $leaf)
+                ->validate(PathValidationConfig::defaultConfig())
+        );
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('without an explicit trust anchor is deprecated', $deprecations[0]);
+    }
+
+    #[Test]
+    public function aSingleSelfSignedCertificateValidatingAsItsOwnAnchorIsAnnounced(): void
+    {
+        [$root] = self::path();
+
+        $deprecations = self::collectDeprecations(
+            static fn () => CertificationPath::create($root)->validate(PathValidationConfig::defaultConfig())
+        );
+
+        static::assertCount(1, $deprecations);
+    }
+
+    #[Test]
+    public function namingTheAnchorIsSilent(): void
+    {
+        [$root, $leaf] = self::path();
+
+        $deprecations = self::collectDeprecations(
+            static fn () => CertificationPath::create($root, $leaf)
+                ->validate(PathValidationConfig::defaultConfig()->withTrustAnchor($root))
+        );
+
+        static::assertSame([], $deprecations);
+    }
+
+    #[Test]
+    public function aPathBuiltFromATrustListIsSilent(): void
+    {
+        // toTarget() heads the path with a certificate out of the bundle the caller supplied, so its head is a
+        // trust anchor the application chose and there is nothing to warn about.
+        [$root, $leaf] = self::path();
+
+        $deprecations = self::collectDeprecations(
+            static fn () => CertificationPath::toTarget($leaf, CertificateBundle::create($root))
+                ->validate(PathValidationConfig::defaultConfig())
+        );
+
+        static::assertSame([], $deprecations);
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function collectDeprecations(callable $fn): array
+    {
+        $collected = [];
+        set_error_handler(static function (int $errno, string $message) use (&$collected): bool {
+            $collected[] = $message;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $fn();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $collected;
+    }
+
+    /**
+     * @return array{Certificate, Certificate}
+     */
+    private static function path(): array
+    {
+        $subject = Name::fromString('cn=Test Root');
+        $validity = Validity::fromStrings('now - 1 hour', 'now + 1 hour');
+
+        $root = TBSCertificate::create($subject, self::$key->publicKeyInfo(), $subject, $validity)
+            ->withSerialNumber('1')
+            ->withAdditionalExtensions(BasicConstraintsExtension::create(true, true))
+            ->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), self::$key);
+
+        $leaf = TBSCertificate::create(
+            Name::fromString('cn=leaf'),
+            self::$key->publicKeyInfo(),
+            $subject,
+            $validity
+        )
+            ->withSerialNumber('2')
+            ->withIssuerCertificate($root)
+            ->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), self::$key);
+
+        return [$root, $leaf];
+    }
+}

--- a/tests/X509/Unit/Ac/AttCertValidityPeriodTest.php
+++ b/tests/X509/Unit/Ac/AttCertValidityPeriodTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\Test\X509\Unit\Ac;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -22,8 +23,8 @@ final class AttCertValidityPeriodTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$_nb = new DateTimeImmutable('2016-05-17 12:00:00');
-        self::$_na = new DateTimeImmutable('2016-05-17 13:00:00');
+        self::$_nb = new DateTimeImmutable('2016-05-17 12:00:00', new DateTimeZone('UTC'));
+        self::$_na = new DateTimeImmutable('2016-05-17 13:00:00', new DateTimeZone('UTC'));
     }
 
     public static function tearDownAfterClass(): void

--- a/tests/X509/Unit/CertificationPath/CertificationPathTest.php
+++ b/tests/X509/Unit/CertificationPath/CertificationPathTest.php
@@ -6,6 +6,7 @@ namespace SpomkyLabs\Pki\Test\X509\Unit\CertificationPath;
 
 use function array_slice;
 use DateTimeImmutable;
+use DateTimeZone;
 use LogicException;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
@@ -73,7 +74,7 @@ final class CertificationPathTest extends TestCase
     public function validate(CertificationPath $path)
     {
         $config = PathValidationConfig::defaultConfig()
-            ->withDateTime(new DateTimeImmutable('2025-01-01'));
+            ->withDateTime(new DateTimeImmutable('2025-01-01', new DateTimeZone('UTC')));
         $result = $path->validate($config);
         static::assertInstanceOf(PathValidationResult::class, $result);
     }

--- a/tests/X509/Unit/CertificationPath/CertificationPathValidationTest.php
+++ b/tests/X509/Unit/CertificationPath/CertificationPathValidationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\Test\X509\Unit\CertificationPath;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use LogicException;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
@@ -44,7 +45,7 @@ final class CertificationPathValidationTest extends TestCase
     public function validateDefault(): PathValidationResult
     {
         $config = PathValidationConfig::defaultConfig()
-            ->withDateTime(new DateTimeImmutable('2025-01-01'));
+            ->withDateTime(new DateTimeImmutable('2025-01-01', new DateTimeZone('UTC')));
         $result = self::$_path->validate($config);
         static::assertInstanceOf(PathValidationResult::class, $result);
         return $result;
@@ -61,7 +62,7 @@ final class CertificationPathValidationTest extends TestCase
     #[Test]
     public function validateExpired()
     {
-        $config = PathValidationConfig::defaultConfig()->withDateTime(new DateTimeImmutable('2026-01-03'));
+        $config = PathValidationConfig::defaultConfig()->withDateTime(new DateTimeImmutable('2026-01-03', new DateTimeZone('UTC')));
         $this->expectException(PathValidationException::class);
         self::$_path->validate($config);
     }
@@ -69,7 +70,7 @@ final class CertificationPathValidationTest extends TestCase
     #[Test]
     public function validateNotBeforeFail()
     {
-        $config = PathValidationConfig::defaultConfig()->withDateTime(new DateTimeImmutable('2015-12-31'));
+        $config = PathValidationConfig::defaultConfig()->withDateTime(new DateTimeImmutable('2015-12-31', new DateTimeZone('UTC')));
         $this->expectException(PathValidationException::class);
         self::$_path->validate($config);
     }
@@ -94,7 +95,7 @@ final class CertificationPathValidationTest extends TestCase
     {
         $config = PathValidationConfig::defaultConfig()
             ->withTrustAnchor(self::$_path->certificates()[0])
-            ->withDateTime(new DateTimeImmutable('2025-01-01'));
+            ->withDateTime(new DateTimeImmutable('2025-01-01', new DateTimeZone('UTC')));
         $validator = PathValidator::create(Crypto::getDefault(), $config, ...self::$_path->certificates());
         static::assertInstanceOf(PathValidationResult::class, $validator->validate());
     }
@@ -106,7 +107,7 @@ final class CertificationPathValidationTest extends TestCase
         $certs = [self::$_path->certificates()[2]];
         $config = PathValidationConfig::defaultConfig()
             ->withTrustAnchor($trustAnchor)
-            ->withDateTime(new DateTimeImmutable('2025-01-01'));
+            ->withDateTime(new DateTimeImmutable('2025-01-01', new DateTimeZone('UTC')));
         $validator = PathValidator::create(Crypto::getDefault(), $config, ...$certs);
         static::assertInstanceOf(PathValidationResult::class, $validator->validate());
     }


### PR DESCRIPTION
Addresses every open hardening issue: #102, #103, #104, #105, #106, #107, #108, #109, #110 and #111.

`Certificate::fromDER($x)->toDER() === $x` now holds, `Element::fromDER()` keeps its documented exception contract, and the X.509 layer no longer trusts a value an attacker chooses where a computed one is available.

## ASN.1 and encoding (#106, #107, #110)

**DER minimality.** A non-minimal long form length, a long form tag below 31, a leading `0x80` continuation octet, a non-minimal INTEGER, an OID sub-identifier starting with `0x80`, an empty OID, the constructed bit on a primitive-only universal type and an empty BIT STRING with non-zero unused bits are rejected. The outer SEQUENCE header, the `signatureAlgorithm` and the `signatureValue` are not covered by the signature, so one legitimately issued certificate used to yield an unbounded family of byte-distinct encodings that all parsed to it — a caller hashing what arrived, which is what browsers, OpenSSL and CT logs do, saw a different certificate each time.

**Exception contract.** The `Element::fromDER()` dispatch is wrapped so any `Throwable` that is not already a `DecodeException` is rethrown as one with the original as previous. `Identifier::intTag()` and `Integer::intNumber()` guard the brick/math conversion the way `Length::intLength()` already did. `Extension::fromASN1()` checks its arity. `Attribute::castValues()` keeps the attribute's own type, so an attribute with an empty value set — which the encoding permits, OpenSSL emits, and this project's own `acme-ecdsa.csr` asset carries — parses instead of raising a `LogicException`.

**Conformance details.** The `validateNumber()` regexes are anchored, `PrintableString` no longer accepts `]`, PEM refuses unpadded base64 and a multi-line label, `fromDER()` writes the offset back when the caller's variable is null, and `RDN::equals()` compares as a multiset so a case difference no longer reorders the DER sort and reports two equal RDNs as different.

## X.509 (#102, #103, #104, #105, #108, #109)

**Certificate identity (#105).** `Certificate::equals()` compared the serial number, the key identifier of the `subjectPublicKeyInfo` and the subject DN — three public values an attacker is free to repeat — so `CertificateBundle::contains()` answered yes for a certificate that was not in the bundle. It now compares the encodings octet by octet with `hash_equals()`. The looser predicate stays available under its own name, `hasEqualSubjectIdentity()`.

**Trust anchoring (#103).** The refusal to fall back to the path's own head was attached to `fromCertificateChain()` rather than to the invariant it protects, so `create()` — the constructor an integrator reaches for first — fell back silently. The fallback now raises `E_USER_DEPRECATED`, so an application can find the call sites before it is removed. A path built by `toTarget()` is headed by a certificate from the caller's own trust list and stays silent.

**Path building (#104).** A certificate without an `authorityKeyIdentifier` could never be chained, which pushed integrators towards that same unsafe constructor; the builder now falls back to matching on the issuer name, as RFC 4158 expects. The bundle indexes a certificate under the key identifier computed from its key as well as the one it declares, and offers the computed match first, so a single certificate repeating a real intermediate's `subjectKeyIdentifier` no longer displaces it and denies validation of a good chain. The equal-length tie-break uses `<=>` rather than a comparator that never returns 0.

**Issuance defaults (#102).** `fromCSR()` never copies an unknown critical extension — it would be signed verbatim and no conforming validator, this library's own included, would then accept the certificate — and raises a deprecation notice when the extensions to copy are not named, ahead of the default becoming an empty allow list. Passing `null` explicitly asks for the current behaviour and stays silent.

**Signature verification (#108).** Ed25519 and Ed448 were advertised in the default allowed algorithms but could not be verified at all. Adding the two OIDs to the digest map is only half the story: `openssl_verify()` grew EdDSA one shot verification recently, and an extension without it reports every EdDSA signature as *invalid* rather than saying so — which is what the first CI run of this branch showed, on runners where a local PHP 8.4 was fine. The engine now verifies RFC 8032's known good test vector once per curve to find out what the runtime can actually do. Where the OpenSSL extension cannot, Ed25519 goes through `ext-sodium`, bundled since PHP 7.2; Ed448 has no such fallback and verification says so plainly, which the bool API turns into "not verified" and path validation fails closed on. `OpenSSLCrypto::supportsSignatureAlgorithm()` answers the question up front. The RSASSA-PSS OID is dropped from both allow lists while PSS is unimplemented — a PSS-signed certificate is refused at parse time, so the entry was dead configuration. `Certificate::verify()`, `CertificationRequest::verify()` and `AttributeCertificate::verify()` are declared `: bool` and now fail closed rather than throw: the algorithm is named by the certificate, so `if (! $cert->verify($key))` was an unhandled fatal on input an attacker controls.

**Attribute certificates (#109).** The evaluation clock is resolved on every evaluation instead of being snapshotted at construction, so a config object shared by a DI container or held across requests in a worker runtime no longer keeps validating expired credentials for the lifetime of the process. The caller's maximum path length is honoured. A `nonRepudiation`-only attribute authority is accepted, as RFC 5755 section 4.5 permits. `ACValidationConfig::withTrustedAttributeAuthorities()` implements section 5 check 4, and the class docblock states that the check is the caller's responsibility when the list is not given.

## Tests (#111)

The reference instants are built with an explicit UTC timezone. `new DateTimeImmutable('2026-01-03')` was read in the server's default timezone while the fixtures' bounds are absolute instants in UTC, so `validateExpired` did not throw on a machine ahead of UTC. The suite is green under `Pacific/Kiritimati` and `Pacific/Midway` as well as locally.

## Compatibility

Everything that only rejects malformed input is enforced outright. The two changes that would break working code are staged as deprecations instead: the implicit trust anchor fallback and the implicit `fromCSR()` deny list both keep working and announce themselves.

`Certificate::equals()` is stricter, which is the point of #105; callers who wanted the loose comparison have `hasEqualSubjectIdentity()`.

## Verification

2871 tests (83 new), ECS, PHPStan and Rector all clean, on PHP 8.1 through 8.5 in both dependency resolutions. The EdDSA cases were also exercised locally on a PHP 8.3 whose OpenSSL extension has no EdDSA and on an 8.4 and 8.5 that do, so both branches of the capability probe are covered. Three existing `SignedStructureMalleabilityTest` cases asserted that a non-minimal encoding parses but fails verification; they now assert the stronger outcome, rejection at decode time.

