### PR TITLE
fix(x509): report an uncomparable name as a path validation or building failure

### DIFF
--- a/src/CryptoBridge/Crypto/OpenSSLCrypto.php
+++ b/src/CryptoBridge/Crypto/OpenSSLCrypto.php
@@ -230,9 +230,6 @@ final class OpenSSLCrypto extends Crypto
     }
 
     /**
-     * Check that given signature algorithm supports key of given type.
-     */
-    /**
      * Whether this engine can check a signature made with the given algorithm.
      *
      * PathValidationConfig advertises Ed25519 and Ed448 in its default allowed set, but whether they can actually
@@ -313,6 +310,12 @@ final class OpenSSLCrypto extends Crypto
         return self::$opensslEdDSASupport[$oid];
     }
 
+    /**
+     * Check that given signature algorithm supports key of given type.
+     *
+     * @param SignatureAlgorithmIdentifier $sig_algo Signature algorithm
+     * @param AlgorithmIdentifier $key_algo Key algorithm
+     */
     protected function _checkSignatureAlgoAndKey(
         SignatureAlgorithmIdentifier $sig_algo,
         AlgorithmIdentifier $key_algo

--- a/src/X501/StringPrep/Exception/StringPreparationException.php
+++ b/src/X501/StringPrep/Exception/StringPreparationException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\X501\StringPrep\Exception;
+
+use UnexpectedValueException;
+
+/**
+ * Exception thrown when a string cannot be prepared for comparison.
+ *
+ * A value carrying a code point that cannot be normalised, case folded or scanned has no prepared form, so no
+ * comparison involving it can answer. The steps fail rather than return a value that would make two different names
+ * compare as one, and the callers that compare names for a security decision turn this into their own failure: the
+ * comparison is refused, never silently answered "not equal".
+ *
+ * It derives from `UnexpectedValueException`, which is what the steps raised before this type existed.
+ */
+final class StringPreparationException extends UnexpectedValueException
+{
+}

--- a/src/X501/StringPrep/MapStep.php
+++ b/src/X501/StringPrep/MapStep.php
@@ -6,7 +6,7 @@ namespace SpomkyLabs\Pki\X501\StringPrep;
 
 use const MB_CASE_FOLD;
 use function preg_replace;
-use RuntimeException;
+use SpomkyLabs\Pki\X501\StringPrep\Exception\StringPreparationException;
 
 /**
  * Implements 'Map' step of the Internationalized String Preparation as specified by RFC 4518.
@@ -71,14 +71,14 @@ final class MapStep implements PrepareStep
     }
 
     /**
-     * @throws RuntimeException If the subject cannot be scanned, which means it is not the UTF-8 the transcode step
-     * is required to produce.
+     * @throws StringPreparationException If the subject cannot be scanned, which means it is not the UTF-8 the
+     * transcode step is required to produce.
      */
     private static function replace(string $pattern, string $replacement, string $subject): string
     {
         $result = preg_replace($pattern, $replacement, $subject);
         if ($result === null) {
-            throw new RuntimeException('Failed to prepare a string that is not valid UTF-8.');
+            throw new StringPreparationException('Failed to prepare a string that is not valid UTF-8.');
         }
 
         return $result;

--- a/src/X501/StringPrep/NormalizeStep.php
+++ b/src/X501/StringPrep/NormalizeStep.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\X501\StringPrep;
 
 use Normalizer;
-use UnexpectedValueException;
+use SpomkyLabs\Pki\X501\StringPrep\Exception\StringPreparationException;
 
 /**
  * Implements 'Normalize' step of the Internationalized String Preparation as specified by RFC 4518.
@@ -23,7 +23,7 @@ final class NormalizeStep implements PrepareStep
         if ($normalized === false) {
             // declared as returning a string, so a failure here would surface as a TypeError, which is an Error
             // and escapes every catch (Exception) a caller wrote around the comparison
-            throw new UnexpectedValueException('Failed to normalize a string for comparison.');
+            throw new StringPreparationException('Failed to normalize a string for comparison.');
         }
 
         return $normalized;

--- a/src/X501/StringPrep/ProhibitStep.php
+++ b/src/X501/StringPrep/ProhibitStep.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\Pki\X501\StringPrep;
 
 use function preg_match;
-use UnexpectedValueException;
+use SpomkyLabs\Pki\X501\StringPrep\Exception\StringPreparationException;
 
 /**
  * Implements 'Prohibit' step of the Internationalized String Preparation as specified by RFC 4518.
@@ -32,16 +32,16 @@ final class ProhibitStep implements PrepareStep
     /**
      * @param string $string UTF-8 encoded string
      *
-     * @throws UnexpectedValueException If the string carries a code point that cannot be compared.
+     * @throws StringPreparationException If the string carries a code point that cannot be compared.
      */
     public function apply(string $string): string
     {
         $found = preg_match(self::PROHIBITED, $string);
         if ($found === false) {
-            throw new UnexpectedValueException('Failed to scan a string that is not valid UTF-8.');
+            throw new StringPreparationException('Failed to scan a string that is not valid UTF-8.');
         }
         if ($found === 1) {
-            throw new UnexpectedValueException('String contains a prohibited character.');
+            throw new StringPreparationException('String contains a prohibited character.');
         }
 
         return $string;

--- a/src/X509/AttributeCertificate/Validation/ACValidationConfig.php
+++ b/src/X509/AttributeCertificate/Validation/ACValidationConfig.php
@@ -109,9 +109,6 @@ final class ACValidationConfig
     }
 
     /**
-     * Get the configuration used to validate the holder and issuer certification paths.
-     */
-    /**
      * Get self with the OID's of the critical extensions the application processes by its own means.
      *
      * The validation rejects an attribute certificate carrying a critical extension it cannot process. Use this
@@ -136,6 +133,9 @@ final class ACValidationConfig
         return $this->additionalCriticalExtensions;
     }
 
+    /**
+     * Get the configuration used to validate the holder and issuer certification paths.
+     */
     public function pathValidationConfig(): PathValidationConfig
     {
         return $this->pathValidationConfig;

--- a/src/X509/Certificate/Extensions.php
+++ b/src/X509/Certificate/Extensions.php
@@ -38,8 +38,6 @@ use UnexpectedValueException;
  * @implements IteratorAggregate<string, Extension>
  *
  * @see https://tools.ietf.org/html/rfc5280#section-4.1.2.9
- *
- * @implements IteratorAggregate<string, Extension>
  */
 final class Extensions implements Countable, IteratorAggregate
 {

--- a/src/X509/CertificationPath/PathBuilding/CertificationPathBuilder.php
+++ b/src/X509/CertificationPath/PathBuilding/CertificationPathBuilder.php
@@ -7,6 +7,7 @@ namespace SpomkyLabs\Pki\X509\CertificationPath\PathBuilding;
 use function count;
 use function hash;
 use function spl_object_id;
+use SpomkyLabs\Pki\X501\StringPrep\Exception\StringPreparationException;
 use SpomkyLabs\Pki\X509\Certificate\Certificate;
 use SpomkyLabs\Pki\X509\Certificate\CertificateBundle;
 use SpomkyLabs\Pki\X509\CertificationPath\CertificationPath;
@@ -80,7 +81,18 @@ final class CertificationPathBuilder
     {
         $this->visitedNodes = 0;
         $this->identities = [];
-        $paths = $this->resolvePathsToTarget($target, $intermediate);
+        try {
+            $paths = $this->resolvePathsToTarget($target, $intermediate);
+        } catch (StringPreparationException $e) {
+            // matching an issuer name is a name comparison, and a name that cannot be prepared for comparison
+            // stops the resolution rather than being reported as not equal. Report it as a building failure like
+            // every other, instead of letting the comparison's own exception escape.
+            throw new PathBuildingException(
+                'A certificate name cannot be prepared for comparison: ' . $e->getMessage(),
+                0,
+                $e
+            );
+        }
         // every path is headed by a certificate taken from the trust list this builder was given, so its head is
         // a trust anchor the application chose
         return array_map(static fn ($certs) => CertificationPath::fromTrustList(...$certs), $paths);

--- a/src/X509/CertificationPath/PathValidation/PathValidator.php
+++ b/src/X509/CertificationPath/PathValidation/PathValidator.php
@@ -11,6 +11,7 @@ use LogicException;
 use RuntimeException;
 use SpomkyLabs\Pki\CryptoBridge\Crypto;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PublicKeyInfo;
+use SpomkyLabs\Pki\X501\StringPrep\Exception\StringPreparationException;
 use SpomkyLabs\Pki\X509\Certificate\Certificate;
 use SpomkyLabs\Pki\X509\Certificate\Extension\CertificatePolicy\PolicyInformation;
 use SpomkyLabs\Pki\X509\Certificate\Extension\Extension;
@@ -103,8 +104,31 @@ final class PathValidator
 
     /**
      * Validate certification path.
+     *
+     * A name comparison is a security decision here, so a name that cannot be prepared for comparison fails the
+     * validation rather than being reported as not equal, which would let a name escape an excluded subtree. The
+     * failure is reported as a PathValidationException like every other, instead of escaping as the
+     * StringPreparationException raised deep inside the comparison.
+     *
+     * @throws PathValidationException If the path does not validate.
      */
     public function validate(): PathValidationResult
+    {
+        try {
+            return $this->process();
+        } catch (StringPreparationException $e) {
+            throw new PathValidationException(
+                'A name of the certification path cannot be prepared for comparison: ' . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+    }
+
+    /**
+     * Run the validation algorithm of RFC 5280 section 6.1.
+     */
+    private function process(): PathValidationResult
     {
         $n = count($this->certificates);
         $state = ValidatorState::initialize($this->config, $this->trustAnchor, $n);

--- a/tests/X509/Regression/UncomparableNameTest.php
+++ b/tests/X509/Regression/UncomparableNameTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\Pki\Test\X509\Regression;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\Pki\CryptoEncoding\PEM;
+use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\Signature\SHA256WithRSAEncryptionAlgorithmIdentifier;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKeyInfo;
+use SpomkyLabs\Pki\X501\ASN1\Name;
+use SpomkyLabs\Pki\X501\StringPrep\Exception\StringPreparationException;
+use SpomkyLabs\Pki\X509\Certificate\Certificate;
+use SpomkyLabs\Pki\X509\Certificate\CertificateBundle;
+use SpomkyLabs\Pki\X509\Certificate\Extension\BasicConstraintsExtension;
+use SpomkyLabs\Pki\X509\Certificate\TBSCertificate;
+use SpomkyLabs\Pki\X509\Certificate\Validity;
+use SpomkyLabs\Pki\X509\CertificationPath\CertificationPath;
+use SpomkyLabs\Pki\X509\CertificationPath\Exception\PathBuildingException;
+use SpomkyLabs\Pki\X509\CertificationPath\Exception\PathValidationException;
+use SpomkyLabs\Pki\X509\CertificationPath\PathBuilding\CertificationPathBuilder;
+use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationConfig;
+
+/**
+ * A name that cannot be prepared for comparison fails the path validation and the path building as such.
+ *
+ * The Prohibit step of RFC 4518 refuses the code points that have no prepared form: a private use character, a
+ * non-character or a replacement character cannot be normalised or case folded, and what a converter does with
+ * them instead is what makes two different names collapse onto one. Refusing them is what keeps a name from
+ * escaping an excluded subtree, so the comparison must fail rather than answer "not equal".
+ *
+ * That failure used to travel out of PathValidator::validate() and CertificationPathBuilder::allPathsToTarget()
+ * as the comparison's own exception, which is neither PathValidationException nor PathBuildingException. An
+ * application catching what those methods document caught nothing, and a single certificate carrying such a name
+ * -- in a bundle a peer supplies, in every common scenario -- turned a handled validation failure into an
+ * unhandled one.
+ *
+ * @internal
+ */
+final class UncomparableNameTest extends TestCase
+{
+    /**
+     * A private use code point: it denotes no character, so it has no prepared form.
+     *
+     * @var string
+     */
+    private const UNCOMPARABLE = "\u{E000}";
+
+    private static ?PrivateKeyInfo $key = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$key = PrivateKey::fromPEM(PEM::fromFile(TEST_ASSETS_DIR . '/certs/keys/acme-ca-rsa.pem'))
+            ->privateKeyInfo();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$key = null;
+    }
+
+    #[Test]
+    public function theComparisonItselfStillFailsClosed(): void
+    {
+        // the guard being restored here is the exception type at the boundary, not the refusal: a name with no
+        // prepared form must never be reported as simply "not equal"
+        $this->expectException(StringPreparationException::class);
+
+        Name::fromString('cn=Acme' . self::UNCOMPARABLE)->equals(Name::fromString('cn=Other'));
+    }
+
+    #[Test]
+    public function validationReportsItAsAPathValidationException(): void
+    {
+        [$root, $leaf] = self::path();
+
+        $this->expectException(PathValidationException::class);
+        $this->expectExceptionMessage('cannot be prepared for comparison');
+
+        CertificationPath::create($root, $leaf)
+            ->validate(PathValidationConfig::defaultConfig()->withTrustAnchor($root));
+    }
+
+    #[Test]
+    public function pathBuildingReportsItAsAPathBuildingException(): void
+    {
+        [$root, $leaf] = self::path();
+
+        $this->expectException(PathBuildingException::class);
+        $this->expectExceptionMessage('cannot be prepared for comparison');
+
+        CertificationPathBuilder::create(CertificateBundle::create($root))
+            ->allPathsToTarget($leaf, CertificateBundle::create($leaf));
+    }
+
+    /**
+     * A root whose subject carries the uncomparable name, and a leaf naming it as its issuer.
+     *
+     * @return array{Certificate, Certificate}
+     */
+    private static function path(): array
+    {
+        $subject = Name::fromString('cn=Test Root' . self::UNCOMPARABLE);
+        $validity = Validity::fromStrings('now - 1 hour', 'now + 1 hour');
+
+        $root = TBSCertificate::create($subject, self::$key->publicKeyInfo(), $subject, $validity)
+            ->withSerialNumber('1')
+            ->withAdditionalExtensions(BasicConstraintsExtension::create(true, true))
+            ->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), self::$key);
+
+        $leaf = TBSCertificate::create(
+            Name::fromString('cn=leaf'),
+            self::$key->publicKeyInfo(),
+            $subject,
+            $validity
+        )
+            ->withSerialNumber('2')
+            ->withIssuerCertificate($root)
+            ->sign(SHA256WithRSAEncryptionAlgorithmIdentifier::create(), self::$key);
+
+        return [$root, $leaf];
+    }
+}


### PR DESCRIPTION
## What

A distinguished name carrying a code point that has no prepared form — a private use character, a non-character, a replacement character — cannot be compared. Normalisation and case folding have nothing to map it to, and what a converter does with it instead is what makes two different names collapse onto one prepared string. The Prohibit step of RFC 4518 therefore refuses it rather than answering the comparison.

**That refusal is deliberate and stays.** Answering `false` would let a name slip past an `excludedSubtrees` constraint, since `NameConstraintsMatcher::matchesDirectoryName()` reads "not equal" as "not excluded".

What it must not do is escape the API as its own type. `Name::equals()` sits on the certification path in four places, none of which caught it:

- `PathValidator::checkNameChaining()`
- `NameConstraintsMatcher::matchesDirectoryName()`
- `Certificate::isSelfIssued()`
- `CertificationPathBuilder::findIssuers()`

A single certificate carrying such a name — in the intermediate bundle a peer supplies, so in TLS, WebAuthn attestation, S/MIME and document signing alike — turned a handled validation failure into an unhandled one. An application catching `PathValidationException` or `PathBuildingException`, which is what those methods document, caught nothing.

## How

- The three preparation steps raise a new `X501\StringPrep\Exception\StringPreparationException`. It **extends `UnexpectedValueException`**, which is what `NormalizeStep` and `ProhibitStep` already raised, so a caller already catching that type is unaffected. `MapStep` raised a plain `RuntimeException`, of which the new type is also a subclass.
- `PathValidator::validate()` translates it into a `PathValidationException`; the algorithm body moves to a private `process()`.
- `CertificationPathBuilder::allPathsToTarget()` translates it into a `PathBuildingException`, which covers `shortestPathToTarget()` too.

Both paths still fail closed. Only the type crossing the API boundary changes.

Also repairs three docblocks left dangling by earlier merges: the duplicated `@implements` on `Extensions`, the description of `ACValidationConfig::pathValidationConfig()` stranded above `withAdditionalCriticalExtensions()`, and the `@param` block of `OpenSSLCrypto::_checkSignatureAlgoAndKey()` stranded above `supportsSignatureAlgorithm()`.

## Backward compatibility

No signature changes. The only API surface delta against the current `1.6.x` head is the addition of `StringPreparationException`; verified by diffing a full parsed dump of every class, method, constant and property before and after.

## Tests

`tests/X509/Regression/UncomparableNameTest.php`, three cases: the comparison itself still fails closed (the guard being restored is the exception type, not the refusal), validation reports a `PathValidationException`, path building reports a `PathBuildingException`.