### PR TITLE
fix(x509): accept a critical subjectAltName during path validation

### DIFF
--- a/src/X509/CertificationPath/PathValidation/PathValidator.php
+++ b/src/X509/CertificationPath/PathValidation/PathValidator.php
@@ -36,9 +36,13 @@ final class PathValidator
      * A critical extension whose OID is not listed here cannot be honoured, and therefore makes the path validation
      * fail as required by RFC 5280 section 6.1.4 (o) and section 6.1.5 (f).
      *
-     * Note that `subjectAltName` is deliberately absent: the validator decodes it, and submits its names to the name
-     * constraints, but does not match an identity against it. An application that enforces it by its own means may
-     * declare it through `PathValidationConfig::withAdditionalCriticalExtensions()`.
+     * `subjectAltName` belongs to that set: RFC 5280 section 6.1.3 (b) and (c) define its processing during path
+     * validation as the matching of its names against the name constraints, which this validator performs. Marking it
+     * critical is moreover what RFC 5280 section 4.2.1.6 requires of a certificate carrying an empty subject, so
+     * rejecting it would turn away the very certificates the specification mandates.
+     *
+     * An extension outside of this set may still be declared by an application enforcing it by its own means, through
+     * `PathValidationConfig::withAdditionalCriticalExtensions()`.
      *
      * @var list<string>
      */
@@ -50,6 +54,7 @@ final class PathValidator
         Extension::OID_POLICY_CONSTRAINTS,
         Extension::OID_INHIBIT_ANY_POLICY,
         Extension::OID_NAME_CONSTRAINTS,
+        Extension::OID_SUBJECT_ALT_NAME,
     ];
 
     /**

--- a/tests/X509/Integration/PathValidation/CriticalExtensionsTest.php
+++ b/tests/X509/Integration/PathValidation/CriticalExtensionsTest.php
@@ -100,6 +100,9 @@ final class CriticalExtensionsTest extends TestCase
                 GeneralSubtrees::create(GeneralSubtree::create(DirectoryName::fromDNString('c=FI')))
             ),
         ];
+        yield 'subjectAltName' => [
+            SubjectAlternativeNameExtension::create(true, GeneralNames::create(DNSName::create('example.com'))),
+        ];
     }
 
     /**
@@ -110,9 +113,6 @@ final class CriticalExtensionsTest extends TestCase
     public static function unprocessedCriticalExtensions(): Iterator
     {
         yield 'unknown' => [self::unknownExtension(true)];
-        yield 'subjectAltName' => [
-            SubjectAlternativeNameExtension::create(true, GeneralNames::create(DNSName::create('example.com'))),
-        ];
         yield 'extendedKeyUsage' => [
             ExtendedKeyUsageExtension::create(true, ExtendedKeyUsageExtension::OID_CLIENT_AUTH),
         ];
@@ -178,13 +178,49 @@ final class CriticalExtensionsTest extends TestCase
     public function criticalExtensionDeclaredInConfigurationDoesNotAcceptOtherExtensions()
     {
         $path = self::createPath([], [
-            SubjectAlternativeNameExtension::create(true, GeneralNames::create(DNSName::create('example.com'))),
+            ExtendedKeyUsageExtension::create(true, ExtendedKeyUsageExtension::OID_CLIENT_AUTH),
         ]);
         $config = PathValidationConfig::create(new DateTimeImmutable(), 3)
             ->withAdditionalCriticalExtensions(self::UNKNOWN_OID);
         $this->expectException(PathValidationException::class);
         $this->expectExceptionMessage('unhandled critical extension');
         $path->validate($config);
+    }
+
+    /**
+     * RFC 5280 section 4.2.1.6 requires a certificate whose subject is empty to carry a critical subjectAltName
+     * extension. Such a certificate is issued in the wild - a TPM attestation identity key certificate is one - and
+     * the validator must not turn it away.
+     */
+    #[Test]
+    public function emptySubjectWithCriticalSubjectAlternativeNameIsAccepted()
+    {
+        $sanExtension = SubjectAlternativeNameExtension::create(
+            true,
+            GeneralNames::create(DNSName::create('example.com'))
+        );
+        $tbs = TBSCertificate::create(
+            Name::fromString(self::CA_NAME),
+            self::$_caKey->publicKeyInfo(),
+            Name::fromString(self::CA_NAME),
+            Validity::fromStrings(null, 'now + 1 hour')
+        );
+        $tbs = $tbs->withAdditionalExtensions(BasicConstraintsExtension::create(true, true, 1));
+        $ca = $tbs->sign(SHA1WithRSAEncryptionAlgorithmIdentifier::create(), self::$_caKey);
+        $tbs = TBSCertificate::create(
+            Name::create(),
+            self::$_certKey->publicKeyInfo(),
+            Name::fromString(self::CA_NAME),
+            Validity::fromStrings(null, 'now + 1 hour')
+        );
+        $tbs = $tbs->withIssuerCertificate($ca)
+            ->withAdditionalExtensions($sanExtension);
+        $cert = $tbs->sign(SHA1WithRSAEncryptionAlgorithmIdentifier::create(), self::$_caKey);
+        $path = CertificationPath::create($ca, $cert);
+
+        $result = $path->validate(PathValidationConfig::create(new DateTimeImmutable(), 3));
+
+        static::assertInstanceOf(PathValidationResult::class, $result);
     }
 
     private static function unknownExtension(bool $critical): UnknownExtension


### PR DESCRIPTION
## The regression

`PathValidator::PROCESSED_EXTENSIONS` left `subjectAltName` out, on the grounds — stated in its own docblock — that the validator decodes the extension but does not act upon it. That stopped being true once name constraints were enforced: `certificateNames()` submits every name of the extension to the permitted and excluded subtrees, and explicitly handles the empty-subject case. That is precisely the processing RFC 5280 section 6.1.3 (b) and (c) define for `subjectAltName` during path validation. The list had simply fallen behind the code, and a critical `subjectAltName` was rejected as an unhandled critical extension.

The rejection turned away conforming certificates. RFC 5280 section 4.2.1.6 **requires** a certificate whose subject is empty to carry a critical `subjectAltName` — so the one shape the specification mandates was the one shape the validator refused.

## How it surfaced

Verifying the downstream libraries against `1.6.x` before release. `web-auth/webauthn-framework` fails on `TPMAttestationStatementSupportTest`: a TPM attestation identity key certificate has an empty subject and a critical `subjectAltName`, so path validation rejects it and TPM attestation is broken for every relying party built on this library.

`git bisect` between `1.6.1` and `1.6.x` points at d9f7ed08, the commit that introduced the critical-extension check.

## The change

- `Extension::OID_SUBJECT_ALT_NAME` joins `PROCESSED_EXTENSIONS`, and the docblock is brought back in line with what the validator actually does.
- `subjectAltName` moves from the `unprocessedCriticalExtensions` provider to `processedCriticalExtensions`.
- `criticalExtensionDeclaredInConfigurationDoesNotAcceptOtherExtensions` used `subjectAltName` as its counter-example and now uses `extendedKeyUsage`.
- A regression test covers the RFC 5280 section 4.2.1.6 shape: an empty subject with a critical `subjectAltName` validates.

`extendedKeyUsage` deliberately stays out. No part of the path validation algorithm acts upon it, and RFC 5280 section 4.2.1.12 leaves its criticality to the issuer's discretion.

## Verification

| | Result |
|---|---|
| pki-framework | 3003 tests, OK |
| ECS | No errors found |
| `web-auth/cose-lib` 4.8.x | 120 tests, OK |
| `web-token/jwt-framework` 4.3.x | 1077 tests, OK |
| `web-auth/webauthn-framework` 5.4.x | 676 tests, error gone |

The three downstream suites were run with this working tree mounted in place of `vendor/spomky-labs/pki-framework`. The remaining webauthn warning and the two jwt incomplete tests predate this change.