### PR TITLE
fix(x509): drop the dead index increments flagged by PHPStan

### DIFF
--- a/src/X509/AttributeCertificate/AttributeCertificateInfo.php
+++ b/src/X509/AttributeCertificate/AttributeCertificateInfo.php
@@ -131,7 +131,7 @@ final class AttributeCertificateInfo
             $obj->issuerUniqueID = UniqueIdentifier::fromASN1($seq->at($idx++)->asBitString());
         }
         if ($seq->has($idx, Element::TYPE_SEQUENCE)) {
-            $obj->extensions = Extensions::fromASN1($seq->at($idx++)->asSequence());
+            $obj->extensions = Extensions::fromASN1($seq->at($idx)->asSequence());
         }
         return $obj;
     }

--- a/src/X509/Certificate/Extension/AAControlsExtension.php
+++ b/src/X509/Certificate/Extension/AAControlsExtension.php
@@ -155,7 +155,7 @@ final class AAControlsExtension extends Extension
             ++$idx;
         }
         if ($seq->has($idx, Element::TYPE_BOOLEAN)) {
-            $permit_unspecified = $seq->at($idx++)
+            $permit_unspecified = $seq->at($idx)
                 ->asBoolean()
                 ->value();
         }


### PR DESCRIPTION
## Problem

The `3️⃣ Static Analysis` job is red on every pull request opened against `1.6.x` since today, for instance #117, whose only change is a `composer.json` constraint:

```
Value of variable $idx after ++ is never read.
  Line   X509/AttributeCertificate/AttributeCertificateInfo.php
  Line   X509/Certificate/Extension/AAControlsExtension.php
```

`composer.json` declares `"minimum-stability": "dev"`, so the pipeline installs `phpstan/phpstan` from its `2.3.x-dev` branch. The last green run on `1.6.x` (2026-09-08) resolved commit `3b094df`; today's runs resolve `1b7038f`, which ships a new dead-write rule. The finding is real, it was simply invisible before.

## Change

In both parsers the sequence index is incremented after its last read, in the final optional field of the sequence. The two post-increments are removed:

```diff
-            $obj->extensions = Extensions::fromASN1($seq->at($idx++)->asSequence());
+            $obj->extensions = Extensions::fromASN1($seq->at($idx)->asSequence());
```

```diff
-            $permit_unspecified = $seq->at($idx++)
+            $permit_unspecified = $seq->at($idx)
```

No behaviour changes: the incremented value was never read.

## Verification

* `make st` with the same `phpstan/phpstan 2.3.x-dev 1b7038f` as the failing run: `[OK] No errors`
* the test suite still passes (3003 tests)

#117 will go green once this is merged and rebased.
