### PR TITLE
test(x509): stop asserting a fixed byte length on a random serial number

### DIFF
--- a/tests/X509/Unit/Certificate/TBSCertificateTest.php
+++ b/tests/X509/Unit/Certificate/TBSCertificateTest.php
@@ -6,7 +6,6 @@ namespace SpomkyLabs\Pki\Test\X509\Unit\Certificate;
 
 use Brick\Math\BigInteger;
 use LogicException;
-use function mb_strlen;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -208,8 +207,9 @@ final class TBSCertificateTest extends TestCase
     public function withRandomSerialNumber(TBSCertificate $tc)
     {
         $tc = $tc->withRandomSerialNumber(16);
-        $bin = BigInteger::of($tc->serialNumber())->toBytes();
-        static::assertSame(16, mb_strlen($bin, '8bit'));
+        $serial = BigInteger::of($tc->serialNumber());
+        static::assertTrue($serial->isPositive());
+        static::assertLessThanOrEqual(127, $serial->getBitLength());
     }
 
     #[Test]


### PR DESCRIPTION
## Problem

`TBSCertificateTest::withRandomSerialNumber` fails at random, most recently on #117 (`ubuntu-latest, 8.3, lowest`), which only touches a `composer.json` constraint:

```
1) SpomkyLabs\Pki\Test\X509\Unit\Certificate\TBSCertificateTest::withRandomSerialNumber
Failed asserting that 15 is identical to 16.
```

With `fail-fast` on the matrix, one such failure cancels the nine other test jobs, so the whole pull request shows red.

`TBSCertificate::generateSerialNumber()` draws `$size` random octets and clears the most significant bit so the DER INTEGER stays positive. That is the documented design. The test however asserts that `BigInteger::toBytes()` returns exactly 16 octets, and `toBytes()` returns the *minimal* two's complement encoding: whenever the leading octet is `0x00` and the next one has its top bit clear (1 draw in 256), the encoding is 15 octets and the assertion fails. Two leading zero octets shorten it further.

## Change

The test now checks the two properties the implementation actually guarantees:

```diff
-        $bin = BigInteger::of($tc->serialNumber())->toBytes();
-        static::assertSame(16, mb_strlen($bin, '8bit'));
+        $serial = BigInteger::of($tc->serialNumber());
+        static::assertTrue($serial->isPositive());
+        static::assertLessThanOrEqual(127, $serial->getBitLength());
```

A positive value of at most 127 bits is exactly "fits in 16 octets as a positive DER INTEGER". Both methods exist since `brick/math` 0.10, the lower bound of the constraint, so the `lowest` jobs are covered. No production code changes.

## Verification

* the problematic draw (`0x00 0x7f ff…`) reproduced deterministically: old assertion fails (15 octets), new one passes
* 20 000 draws of `generateSerialNumber(16)` against the new assertion: 0 violation
* full suite: 3003 tests, ECS and PHPStan clean
